### PR TITLE
Using a `NSMapTable` to hold references to associated objects

### DIFF
--- a/Sources/AssociatedObjectStore.swift
+++ b/Sources/AssociatedObjectStore.swift
@@ -6,31 +6,82 @@
 //  Copyright © 2017 Suyeol Jeon. All rights reserved.
 //
 
-import ObjectiveC
+import Foundation
 
-public protocol AssociatedObjectStore {
+public protocol AssociatedObjectStore : class {}
+
+
+internal enum AssociatedObjectKey : String {
+    case actionSubject
+    case action
+    case currentState
+    case state
+    case reactor
 }
 
+let map = NSMapTable<AnyObject, NSMutableDictionary>.strongToStrongObjects()
+
 extension AssociatedObjectStore {
-  func associatedObject<T>(forKey key: UnsafeRawPointer) -> T? {
-    return objc_getAssociatedObject(self, key) as? T
-  }
-
-  func associatedObject<T>(forKey key: UnsafeRawPointer, default: () -> T) -> T {
-    return self.associatedObject(forKey: key, default: `default`())
-  }
-
-  func associatedObject<T>(forKey key: UnsafeRawPointer, default: @autoclosure () -> T) -> T {
-    if let object: T = self.associatedObject(forKey: key) {
-      return object
+   func associatedObject<T>(forKey key: AssociatedObjectKey) -> T? {
+        let container = map.object(forKey: self as AnyObject)
+        return container?.object(forKey: key.rawValue) as? T
     }
-    let object = `default`()
-    self.setAssociatedObject(object, forKey: key)
-    return object
-  }
+    
 
-  func setAssociatedObject<T>(_ object: T?, forKey key: UnsafeRawPointer) {
-    objc_setAssociatedObject(self, key, object, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-  }
+    func associatedObject<T>(forKey key: AssociatedObjectKey, default handler: @autoclosure () -> T) -> T {
+        if let object: T = self.associatedObject(forKey: key) { return object }
+        let object = handler()
+        self.setAssociatedObject(object, forKey: key)
+        return object
+    }
+    
+    func associatedObject<T>(forKey key: AssociatedObjectKey, _ handler: () -> T) -> T {
+        return self.associatedObject(forKey: key, default: handler())
+    }
+
+    
+    func setAssociatedObject<T>(_ object: T?, forKey key: AssociatedObjectKey) {
+        let container: NSMutableDictionary
+        switch map.object(forKey: self as AnyObject) {
+        case let exists?:
+            container = exists
+        default:
+            container = NSMutableDictionary()
+            map.setObject(container, forKey: self)
+        }
+        if let object = object {
+            container.setObject(object, forKey: key.rawValue as NSCopying)
+        }
+        else { container.removeObject(forKey: key.rawValue)}
+    }
+
+    func removeAssociatedObject(forKey key: AssociatedObjectKey) {
+        let removal:Any? = nil
+        
+        self.setAssociatedObject(removal, forKey: key)
+    }
+
+
+
+//  func associatedObject<T>(forKey key: UnsafeRawPointer) -> T? {
+//    return objc_getAssociatedObject(self, key) as? T
+//  }
+//
+//  func associatedObject<T>(forKey key: UnsafeRawPointer, default: () -> T) -> T {
+//    return self.associatedObject(forKey: key, default: `default`())
+//  }
+//
+//  func associatedObject<T>(forKey key: UnsafeRawPointer, default: @autoclosure () -> T) -> T {
+//    if let object: T = self.associatedObject(forKey: key) {
+//      return object
+//    }
+//    let object = `default`()
+//    self.setAssociatedObject(object, forKey: key)
+//    return object
+//  }
+//
+//  func setAssociatedObject<T>(_ object: T?, forKey key: UnsafeRawPointer) {
+//    objc_setAssociatedObject(self, key, object, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+//  }
 }
 

--- a/Sources/AssociatedObjectStore.swift
+++ b/Sources/AssociatedObjectStore.swift
@@ -22,7 +22,8 @@ internal enum AssociatedObjectKey : String {
 let map = NSMapTable<AnyObject, NSMutableDictionary>.strongToStrongObjects()
 
 extension AssociatedObjectStore {
-   func associatedObject<T>(forKey key: AssociatedObjectKey) -> T? {
+
+    func associatedObject<T>(forKey key: AssociatedObjectKey) -> T? {
         let container = map.object(forKey: self as AnyObject)
         return container?.object(forKey: key.rawValue) as? T
     }
@@ -39,7 +40,6 @@ extension AssociatedObjectStore {
         return self.associatedObject(forKey: key, default: handler())
     }
 
-    
     func setAssociatedObject<T>(_ object: T?, forKey key: AssociatedObjectKey) {
         let container: NSMutableDictionary
         switch map.object(forKey: self as AnyObject) {
@@ -57,31 +57,8 @@ extension AssociatedObjectStore {
 
     func removeAssociatedObject(forKey key: AssociatedObjectKey) {
         let removal:Any? = nil
-        
         self.setAssociatedObject(removal, forKey: key)
     }
 
-
-
-//  func associatedObject<T>(forKey key: UnsafeRawPointer) -> T? {
-//    return objc_getAssociatedObject(self, key) as? T
-//  }
-//
-//  func associatedObject<T>(forKey key: UnsafeRawPointer, default: () -> T) -> T {
-//    return self.associatedObject(forKey: key, default: `default`())
-//  }
-//
-//  func associatedObject<T>(forKey key: UnsafeRawPointer, default: @autoclosure () -> T) -> T {
-//    if let object: T = self.associatedObject(forKey: key) {
-//      return object
-//    }
-//    let object = `default`()
-//    self.setAssociatedObject(object, forKey: key)
-//    return object
-//  }
-//
-//  func setAssociatedObject<T>(_ object: T?, forKey key: UnsafeRawPointer) {
-//    objc_setAssociatedObject(self, key, object, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-//  }
 }
 

--- a/Sources/AssociatedObjectStore.swift
+++ b/Sources/AssociatedObjectStore.swift
@@ -49,9 +49,7 @@ extension AssociatedObjectStore {
             container = NSMutableDictionary()
             map.setObject(container, forKey: self)
         }
-        if let object = object {
-            container.setObject(object, forKey: key.rawValue as NSCopying)
-        }
+        if let object = object { container.setObject(object, forKey: key.rawValue as NSCopying) }
         else { container.removeObject(forKey: key.rawValue)}
     }
 

--- a/Sources/Reactor.swift
+++ b/Sources/Reactor.swift
@@ -12,7 +12,7 @@ public struct NoAction {}
 public struct NoMutation {}
 
 public typealias _Reactor = Reactor
-public protocol Reactor: class, AssociatedObjectStore {
+public protocol Reactor: AssociatedObjectStore {
   associatedtype Action
   associatedtype Mutation = Action
   associatedtype State
@@ -54,6 +54,7 @@ public protocol Reactor: class, AssociatedObjectStore {
 
 // MARK: - Associated Object Keys
 
+
 private var actionSubjectKey = "actionSubject"
 private var actionKey = "action"
 private var currentStateKey = "currentState"
@@ -64,21 +65,21 @@ private var stateKey = "state"
 
 extension Reactor {
   internal var actionSubject: PublishSubject<Action> {
-    get { return self.associatedObject(forKey: &actionSubjectKey, default: .init()) }
-    set { self.setAssociatedObject(newValue, forKey: &actionSubjectKey) }
+    get { return self.associatedObject(forKey: .action, default: .init()) }
+    set { self.setAssociatedObject(newValue, forKey: .actionSubject) }
   }
 
   public var action: AnyObserver<Action> {
-    get { return self.associatedObject(forKey: &actionKey, default: self.actionSubject.asObserver()) }
+    get { return self.associatedObject(forKey: .action, default: self.actionSubject.asObserver()) }
   }
 
   public var currentState: State {
-    get { return self.associatedObject(forKey: &currentStateKey, default: self.initialState) }
-    set { self.setAssociatedObject(newValue, forKey: &currentStateKey) }
+    get { return self.associatedObject(forKey: .currentState, default: self.initialState) }
+    set { self.setAssociatedObject(newValue, forKey: .currentState) }
   }
 
   public var state: Observable<State> {
-    get { return self.associatedObject(forKey: &stateKey, default: self.createStateStream()) }
+    get { return self.associatedObject(forKey: .state, default: self.createStateStream()) }
   }
 
   public func createStateStream() -> Observable<State> {

--- a/Sources/View.swift
+++ b/Sources/View.swift
@@ -25,19 +25,15 @@ public protocol View: class, AssociatedObjectStore {
 }
 
 
-// MARK: - Associated Object Keys
-
-private var reactorKey = "reactor"
-
 
 // MARK: - Default Implementations
 
 extension View {
   public var reactor: Reactor? {
-    get { return self.associatedObject(forKey: &reactorKey) }
+    get { return self.associatedObject(forKey: .reactor) }
     set {
       guard self.reactor !== newValue else { return }
-      self.setAssociatedObject(newValue, forKey: &reactorKey)
+      self.setAssociatedObject(newValue, forKey: .reactor)
       self.disposeBag = DisposeBag()
       if let reactor = newValue {
         self.bind(reactor: reactor)

--- a/Tests/ReactorTests/AssociatedObjectStoreTests.swift
+++ b/Tests/ReactorTests/AssociatedObjectStoreTests.swift
@@ -1,0 +1,61 @@
+//
+//  AssociatedObjectStoreTests.swift
+//  ReactorKit
+//
+//  Created by Seivan Heidari on 17/04/22.
+//
+//
+
+import XCTest
+@testable import ReactorKit
+
+class Dummy : AssociatedObjectStore {
+    
+}
+
+class AssociatedObjectStoreTests: XCTestCase {
+    
+    var subject:Dummy!
+    override func setUp() {
+        super.setUp()
+        self.subject = Dummy()
+        
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    
+    func testKeysAreRegistered() {
+        let action = Date()
+        self.subject.setAssociatedObject(action, forKey: .action)
+        XCTAssertEqual(action, self.subject.associatedObject(forKey: .action))
+    
+    }
+    
+    func testKeysAreRemoved() {
+        let action = Date()
+        self.subject.setAssociatedObject(action, forKey: .action)
+        self.subject.removeAssociatedObject(forKey: .action)
+        
+        XCTAssertNil(self.subject.associatedObject(forKey: .action))
+        
+        
+    }
+    
+    func testKeysReplaceExistingValues() {
+        let action = Date()
+        self.subject.setAssociatedObject(action, forKey: .action)
+        let newAction = Date()
+        self.subject.setAssociatedObject(newAction, forKey: .action)
+        XCTAssertEqual(newAction, self.subject.associatedObject(forKey: .action))
+        XCTAssertNotEqual(newAction, action)
+        
+    }
+
+    
+    
+}

--- a/Tests/ReactorTests/AssociatedObjectStoreTests.swift
+++ b/Tests/ReactorTests/AssociatedObjectStoreTests.swift
@@ -7,11 +7,10 @@
 //
 
 import XCTest
+
 @testable import ReactorKit
 
-class Dummy : AssociatedObjectStore {
-    
-}
+class Dummy : AssociatedObjectStore {}
 
 class AssociatedObjectStoreTests: XCTestCase {
     
@@ -19,19 +18,13 @@ class AssociatedObjectStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.subject = Dummy()
-        
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
     }
     
     
     func testKeysAreRegistered() {
         let action = Date()
         self.subject.setAssociatedObject(action, forKey: .action)
+
         XCTAssertEqual(action, self.subject.associatedObject(forKey: .action))
     
     }
@@ -51,6 +44,7 @@ class AssociatedObjectStoreTests: XCTestCase {
         self.subject.setAssociatedObject(action, forKey: .action)
         let newAction = Date()
         self.subject.setAssociatedObject(newAction, forKey: .action)
+
         XCTAssertEqual(newAction, self.subject.associatedObject(forKey: .action))
         XCTAssertNotEqual(newAction, action)
         

--- a/Tests/ReactorTests/ReactorTests.swift
+++ b/Tests/ReactorTests/ReactorTests.swift
@@ -5,7 +5,7 @@ class ReactorKitTests: XCTestCase {
   func testExample() {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct results.
-    XCTAssertEqual(ReactorKit().text, "Hello, World!")
+
   }
 
 


### PR DESCRIPTION
* Protect against other third party libraries with duplicate keys as associated object.  The 'state' key could be quite common. This is slightly better than namespaces which is an alternative solution. 

* Using an enum `AssociatedObjectKey` with a rawValue to avoid duplicate strings and make it easier to add new properties if needed.