### PR TITLE
Add autosubscribe feature

### DIFF
--- a/Tests/ReactorKitTests/ReactorTests.swift
+++ b/Tests/ReactorKitTests/ReactorTests.swift
@@ -20,13 +20,19 @@ final class ReactorTests: XCTestCase {
     }
   }
 
-  func testCurrentState() {
-    let disposeBag = DisposeBag()
+  func testCurrentState_autosubscribe() {
     let reactor = TestReactor()
     XCTAssertEqual(reactor.currentState, [])
-    reactor.state.subscribe().disposed(by: disposeBag)
+    reactor.autosubscribe()
     reactor.action.onNext(["action"])
     XCTAssertEqual(reactor.currentState, ["action", "transformedAction", "mutation", "transformedMutation", "transformedState"])
+  }
+
+  func testCurrentState_noSubscribe() {
+    let reactor = TestReactor()
+    XCTAssertEqual(reactor.currentState, [])
+    reactor.action.onNext(["action"])
+    XCTAssertEqual(reactor.currentState, [])
   }
 
   func testStreamNotContainsError() {


### PR DESCRIPTION
A state stream is a cold observable by default. So the states are not changed until the view subscribes the state stream. `autosubscribe()` changes the state stream behavior from cold observable to hot observable. This is useful when using reactors with reusable views.