### PR TITLE
Fix LICENSE link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,4 +347,4 @@ Join [#reactorkit](https://rxswift.slack.com/messages/C561PETRN/) on [RxSwift Sl
 
 ## License
 
-ReactorKit is under MIT license. See the [LICENSE](LICENSE) for more info.
+ReactorKit is under MIT license. See the [LICENSE](https://github.com/ReactorKit/ReactorKit/blob/master/LICENSE) for more info.


### PR DESCRIPTION
I found that it cannot be opened in Doc page(http://reactorkit.io/docs/latest). 

I suggest this explicit link to solve this issue.