### PR TITLE
Bypass a Swift compiler bug in generic subclass associated object

### DIFF
--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -74,12 +74,17 @@ private var stubKey = "stub"
 // MARK: - Default Implementations
 
 extension Reactor {
-  public var action: ActionSubject<Action> {
+  private var _action: ActionSubject<Action> {
     if self.stub.isEnabled {
       return self.stub.action
     } else {
       return self.associatedObject(forKey: &actionKey, default: .init())
     }
+  }
+  public var action: ActionSubject<Action> {
+    // It seems that Swift has a bug in associated object when subclassing a generic class. This is
+    // a temporary solution to bypass the bug. See #30 for details.
+    return self._action
   }
 
   public internal(set) var currentState: State {
@@ -100,7 +105,7 @@ extension Reactor {
   }
 
   public func createStateStream() -> Observable<State> {
-    let action = self.action.asObservable()
+    let action = self._action.asObservable()
     let transformedAction = self.transform(action: action)
     let mutation = transformedAction
       .flatMap { [weak self] action -> Observable<Mutation> in

--- a/Tests/ReactorKitTests/ReactorTests.swift
+++ b/Tests/ReactorKitTests/ReactorTests.swift
@@ -195,6 +195,25 @@ final class ReactorTests: XCTestCase {
     reactor.action.onNext(["A"])
     XCTAssertEqual(reactor.currentState, [])
   }
+
+  /// A test for #30
+  func testGenericSubclassing() {
+    class ParentReactor<T>: Reactor {
+      enum Action {}
+      typealias Mutation = Void
+      typealias State = Void
+      let initialState: State = State()
+    }
+
+    class ChildReactor: ParentReactor<String> {
+    }
+
+    let reactor = ChildReactor()
+    let address1 = ObjectIdentifier(reactor.action).hashValue
+    _ = reactor.state
+    let address2 = ObjectIdentifier(reactor.action).hashValue
+    XCTAssertEqual(address1, address2)
+  }
 }
 
 struct TestError: Error {


### PR DESCRIPTION
I found something weird. Reactor's `action` is created again after the state stream is created when subclassing a generic class.

```swift
// Generic class
class ParentReactor<T>: Reactor {
  enum Action {}
  typealias Mutation = Void
  typealias State = Void
  let initialState: State = State()
}

// Subclass
class ChildReactor: ParentReactor<String> {
}

let reactor = ChildReactor()
let address1 = ObjectIdentifier(reactor.action).hashValue // 140212178080688
_ = reactor.state // will call createStateSteam()
let address2 = ObjectIdentifier(reactor.action).hashValue // 140212178094112
XCTAssertEqual(address1, address2) // FAIL
```
