### PR TITLE
Add StoryboardView protocol for manual bindings

### DIFF
--- a/Sources/View.swift
+++ b/Sources/View.swift
@@ -7,19 +7,7 @@
 //
 
 #if !os(Linux)
-import Foundation
-
-#if os(iOS) || os(tvOS)
-import UIKit
-private typealias OSViewController = UIViewController
-#elseif os(OSX)
-import AppKit
-private typealias OSViewController = NSViewController
-#endif
-
 import RxSwift
-
-public typealias _View = View
 
 /// A View displays data. A view controller and a cell are treated as a view. The view binds user
 /// inputs to the action stream and binds the view states to each UI component. There's no business
@@ -73,28 +61,8 @@ extension View {
     self.setAssociatedObject(reactor, forKey: &reactorKey)
     self.disposeBag = DisposeBag()
     if let reactor = reactor {
-      self.performBinding(reactor: reactor)
-    }
-  }
-
-  fileprivate func performBinding(reactor: Reactor) {
-    guard self.reactor === reactor else { return }
-    if self.shouldDeferBinding(reactor: reactor) {
-      DispatchQueue.main.async { [weak self, weak reactor] in
-        guard let `self` = self, let reactor = reactor else { return }
-        self.performBinding(reactor: reactor)
-      }
-    } else {
       self.bind(reactor: reactor)
     }
-  }
-
-  fileprivate func shouldDeferBinding(reactor: Reactor) -> Bool {
-    #if !os(watchOS)
-      return (self as? OSViewController)?.isViewLoaded == false
-    #else
-      return false
-    #endif
   }
 }
 #endif

--- a/Sources/View.swift
+++ b/Sources/View.swift
@@ -54,14 +54,37 @@ private var reactorKey = "reactor"
 extension View {
   public var reactor: Reactor? {
     get { return self.associatedObject(forKey: &reactorKey) }
-    set { self.setReactor(newValue) }
+    set {
+      self.setAssociatedObject(newValue, forKey: &reactorKey)
+      self.disposeBag = DisposeBag()
+      if let reactor = newValue {
+        self.bind(reactor: reactor)
+      }
+    }
+  }
+}
+
+public protocol StoryboardView: View, AssociatedObjectStore {
+  /// Makes `bind(reactor:)` get called. Nothing happens if the `reactor` is not set.
+  func bindReactor(file: StaticString, line: Int)
+}
+
+extension StoryboardView {
+  public var reactor: Reactor? {
+    get { return self.associatedObject(forKey: &reactorKey) }
+    set {
+      self.setAssociatedObject(newValue, forKey: &reactorKey)
+      self.disposeBag = DisposeBag()
+    }
   }
 
-  fileprivate func setReactor(_ reactor: Reactor?) {
-    self.setAssociatedObject(reactor, forKey: &reactorKey)
-    self.disposeBag = DisposeBag()
-    if let reactor = reactor {
+  public func bindReactor(file: StaticString = #file, line: Int = #line) {
+    if let reactor = self.reactor {
       self.bind(reactor: reactor)
+    } else {
+      #if DEBUG
+      print("⚠️ \(file):\(line): warning: bindReactor() is called but a reactor is not set.")
+      #endif
     }
   }
 }

--- a/Tests/ReactorKitTests/ViewTests.swift
+++ b/Tests/ReactorKitTests/ViewTests.swift
@@ -2,16 +2,6 @@ import XCTest
 import ReactorKit
 import RxSwift
 
-#if os(iOS) || os(tvOS)
-import UIKit
-private typealias OSViewController = UIViewController
-private typealias OSView = UIView
-#elseif os(OSX)
-import AppKit
-private typealias OSViewController = NSViewController
-private typealias OSView = NSView
-#endif
-
 #if !os(Linux)
 final class ViewTests: XCTestCase {
   func testBindIsInvoked_differentReactor() {
@@ -47,61 +37,17 @@ final class ViewTests: XCTestCase {
     XCTAssertNil(view.reactor)
   }
 
-  func testViewController_alreadyHasView() {
-    let viewController = TestViewController()
-    _ = viewController.view
-    viewController.reactor = TestReactor()
-    XCTAssertEqual(viewController.isViewLoaded, true)
-    XCTAssertEqual(viewController.bindInvokeCount, 1)
-  }
-
-  func testDeferBinding() {
-    let viewController = TestViewController()
-    viewController.reactor = TestReactor()
-    XCTAssertEqual(viewController.bindInvokeCount, 0) // view is not loaded yet; skip binding
-    _ = viewController.view // makes `loadView()` get called
-
-    let expectation = self.expectation(description: "bindInvokeCountExpectation")
-    DispatchQueue.main.async(execute: expectation.fulfill)
-    self.waitForExpectations(timeout: 0.5) { error in
-      XCTAssertNil(error)
-      XCTAssertEqual(viewController.bindInvokeCount, 1)
-    }
-  }
-
-  func testDeferBinding_deinitWhileDeferred() {
-    weak var weakView: TestViewController?
-    weak var weakReactor: TestReactor?
-    _ = {
-      let viewController = TestViewController()
-      let reactor = TestReactor()
-      weakView = viewController
-      weakReactor = reactor
-      viewController.reactor = reactor // this will start waiting for view
-      XCTAssertNotNil(weakView)
-      XCTAssertNotNil(weakReactor)
-    }() // viewController is deallocated while waiting (before the view is loaded)
-    XCTAssertNil(weakView)
-    XCTAssertNil(weakReactor)
-  }
-
-  func testDeferBinding_changeReactorWhileDeferred() {
-    let viewController = TestViewController()
-    viewController.reactor = TestReactor()
-    XCTAssertEqual(viewController.bindInvokeCount, 0)
-    viewController.reactor = TestReactor() // assign a new reactor
-    XCTAssertEqual(viewController.bindInvokeCount, 0)
-    _ = viewController.view // makes `loadView()` get called
-    XCTAssertEqual(viewController.bindInvokeCount, 0)
-
-    let expectation = self.expectation(description: "bindInvokeCountExpectation")
-    DispatchQueue.main.async(execute: expectation.fulfill)
-    self.waitForExpectations(timeout: 0.5) { error in
-      XCTAssertNil(error)
-      XCTAssertEqual(viewController.bindInvokeCount, 1)
-      viewController.reactor = TestReactor() // assign a new reactor after view is loaded
-      XCTAssertEqual(viewController.bindInvokeCount, 2)
-    }
+  func testStoryboardView_performBinding() {
+    let reactor = TestReactor()
+    let view = TestStoryboardView()
+    view.reactor = reactor
+    XCTAssertEqual(view.bindInvokeCount, 0)
+    view.bindReactor()
+    XCTAssertEqual(view.bindInvokeCount, 1)
+    view.reactor = reactor
+    XCTAssertEqual(view.bindInvokeCount, 1)
+    view.bindReactor()
+    XCTAssertEqual(view.bindInvokeCount, 2)
   }
 }
 
@@ -114,13 +60,9 @@ private final class TestView: View {
   }
 }
 
-private final class TestViewController: OSViewController, View {
+private final class TestStoryboardView: StoryboardView {
   var disposeBag = DisposeBag()
   var bindInvokeCount = 0
-
-  override func loadView() {
-    self.view = OSView()
-  }
 
   func bind(reactor: TestReactor) {
     self.bindInvokeCount += 1


### PR DESCRIPTION
There are some bugs(#31) and a dark side of a behind magic. I think an explicitness is better than an implicitness. This PR reverts the binding behavior to 0.4.x and let users to choose the timing of bindings.

A new protocol `StoryboardView` is almost same as `View` but it will not call `bind(reactor:)` automatically when the reactor is assigned. You should call `bindReactor()` when you'd like to perform bindings.

## Breaking API Changes

This PR contains breaking API changes as it reverts the binding behavior. Assigning a reactor to a `View` will immediately execute `bind(reactor:)`. If a view controller is created using Storyboard, the view controller should conform to a protocol `StoryboardView` and you have to perform bindings manually using `bindReactor()`.

```swift
class MyViewController: UIViewController, StoryboardView {
  override func viewDidLoad() {
    super.viewDidLoad()
    self.bindReactor() // makes `bind(reactor:)` get called
  }

  func bind(reactor: MyViewReactor) {
  }
}
```

## Discussion

How about adding #28 to `StoryboardView` only? I think I can swizzle a `viewDidLoad()` instead of `loadView()` in this case.
