### PR TITLE
Create a state stream as the action property being accessed

### DIFF
--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -84,6 +84,7 @@ extension Reactor {
   public var action: ActionSubject<Action> {
     // It seems that Swift has a bug in associated object when subclassing a generic class. This is
     // a temporary solution to bypass the bug. See #30 for details.
+    _ = self.state
     return self._action
   }
 

--- a/Tests/ReactorKitTests/ReactorTests.swift
+++ b/Tests/ReactorKitTests/ReactorTests.swift
@@ -40,7 +40,7 @@ final class ReactorTests: XCTestCase {
   func testCurrentState_noState() {
     let reactor = TestReactor()
     reactor.action.onNext(["action"])
-    XCTAssertEqual(reactor.currentState, [])
+    XCTAssertEqual(reactor.currentState, ["action", "transformedAction", "mutation", "transformedMutation", "transformedState"])
   }
 
   func testStreamIgnoresErrorFromAction() {


### PR DESCRIPTION
## Why

If the state weren't subscribed from anywhere, actions sent to Reactor would be simply ignored.

```swift
func bind(reactor: Reactor) {
        reactor.action.onNext(.load)
}
```

## What

Touch `state` property in `action` property to ensure the initialization of the state stream