### PR TITLE
Add Carthage troubleshooting info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ReactorKit is a framework for a reactive and unidirectional Swift application architecture. This repository introduces the basic concept of ReactorKit and describes how to build an application using ReactorKit.
 
-You may want to see the [Examples](#examples) section first if you'd like to see the actual code. Visit the [API Reference](http://reactorkit.io/docs/latest/) for code-level documentation.  
+You may want to see the [Examples](#examples) section first if you'd like to see the actual code. Visit the [API Reference](http://reactorkit.io/docs/latest/) for code-level documentation.
 
 For an overview of ReactorKit's features and the reasoning behind its creation, you may also check the slides from this introductory presentation over at [SlideShare](https://www.slideshare.net/devxoul/hello-reactorkit).
 
@@ -168,7 +168,7 @@ func mutate(action: Action) -> Observable<Mutation> {
 
 #### `reduce()`
 
-`reduce()` generates a new `State` from a previous `State` and a `Mutation`. 
+`reduce()` generates a new `State` from a previous `State` and a `Mutation`.
 
 ```swift
 func reduce(state: State, mutation: Mutation) -> State
@@ -378,9 +378,24 @@ ReactorKit officially supports CocoaPods only.
 pod 'ReactorKit'
 ```
 
+ReactorKit does not officially support Carthage.
+
+**Cartfile**
+
+```ruby
+github 'ReactorKit/ReactorKit'
+```
+
+Most Carthage installation issues can be resolved with the following:
+```sh
+carthage update 2>/dev/null
+(cd Carthage/Checkouts/ReactorKit && swift package generate-xcodeproj)
+carthage build
+```
+
 ## Contribution
 
-Any discussions and pull requests are welcomed 💖 
+Any discussions and pull requests are welcomed 💖
 
 * To development:
 


### PR DESCRIPTION
I plan on helping out with your PR for SPM support for Carthage (https://github.com/Carthage/Carthage/pull/1945), but in the meantime I think it would reduce your support burden if users could more easily find out how to use ReactorKit with Carthage. In other words, this means fewer issues like #81 or #65

PS: My text editor ate some whitespace, but I hope you don't mind ;)