### PR TITLE
修复实现StoryboardView协议，提前bind导致的Crash

### DIFF
--- a/Sources/ReactorKitRuntime/ReactorKitRuntime.m
+++ b/Sources/ReactorKitRuntime/ReactorKitRuntime.m
@@ -45,7 +45,7 @@
 
   IMP newMethodImp = imp_implementationWithBlock(^(__unsafe_unretained id self) {
     oldMethodImp(self, oldSelector);
-    if ([self respondsToSelector:performBindingSelector]) {
+    if ([self respondsToSelector:performBindingSelector] && [self class] == class) {
       #pragma clang diagnostic push
       #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
       [self performSelector:performBindingSelector];


### PR DESCRIPTION
Fix crash, because the SubViewController maybe inherit a BaseViewController, all the UI not initialization