### PR TITLE
Add subscribe(relay:StateRelay) on ObservableType extension

### DIFF
--- a/Sources/ReactorKit/StateRelay.swift
+++ b/Sources/ReactorKit/StateRelay.swift
@@ -50,3 +50,27 @@ public final class StateRelay<Element>: ObservableType {
         return _subject.asObservable()
     }
 }
+
+extension ObservableType {
+    public func subscribe(_ relay: StateRelay<E>) -> Disposable {
+        return subscribe { e in
+            switch e {
+            case let .next(element):
+                relay.accept(element)
+            case let .error(error):
+                let errorMessage = "Binding error to stateRelay: \(error)"
+                #if DEBUG
+                fatalError(errorMessage)
+                #else
+                print("\(file):\(line): \(errorMessage)")
+                #endif
+            case .completed:
+                break
+            }
+        }
+    }
+
+    public func subscribe(_ relay: StateRelay<E?>) -> Disposable {
+        return self.map { $0 as E? }.subscribe(relay)
+    }
+}


### PR DESCRIPTION
MVVM recommend not import `UIKit` on ViewModel.
I agree too. 

`BehaviorRelay` is often used for convenience.
However, `BehaviorRelay` defined on`RxCocoa`, which import `UIKit`.

So I suggest using `StateRelay` instead of `BehaviorRelay`.
`StateRelay` is the same as `BehaviorRelay`. So there won't be a problem with it.

Also, I suggest using `subscribe(...)` instead of `bind(to:)` on ViewModel.

Thanks!