### PR TITLE
Fix the parsing error for Carthage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,8 @@ ReactorKit does not officially support Carthage.
 
 **Cartfile**
 
-```ruby
-github 'ReactorKit/ReactorKit'
+```swift
+github "ReactorKit/ReactorKit"
 ```
 
 Most Carthage installation issues can be resolved with the following:


### PR DESCRIPTION
Cathage seems to allow only `"` not `'` as a quote in the syntax.
And also, Carthage made by swift, that's why to change the syntax highlight for Carthage example.

https://github.com/Carthage/Carthage/blob/master/Source/CarthageKit/Cartfile.swift#L190