### PR TITLE
Let's Combine 🚀

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
   ],
   products: [
     .library(name: "ReactorKit", targets: ["ReactorKit"]),
+    .library(name: "ReactorKitCombine", targets: ["ReactorKitCombine"]),
   ],
   dependencies: [
     .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
@@ -17,8 +18,10 @@ let package = Package(
   ],
   targets: [
     .target(name: "ReactorKit", dependencies: ["ReactorKitRuntime", "RxSwift", "WeakMapTable"]),
+    .target(name: "ReactorKitCombine", dependencies: ["WeakMapTable"]),
     .target(name: "ReactorKitRuntime", dependencies: []),
     .testTarget(name: "ReactorKitTests", dependencies: ["ReactorKit", "RxExpect"]),
+    .testTarget(name: "ReactorKitCombineTests", dependencies: ["ReactorKitCombine"]),
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/Sources/ReactorKitCombine/ActionSubject.swift
+++ b/Sources/ReactorKitCombine/ActionSubject.swift
@@ -1,0 +1,93 @@
+//
+//  ActionSubject.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/25.
+//
+
+import Combine
+import class Foundation.NSLock.NSRecursiveLock
+
+/// A special subject for Reactor's Action. It only emits `.next` event.
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public final class ActionSubject<Output>: Combine.Subject {
+
+  public typealias Output = Output
+  public typealias Failure = Swift.Never
+
+  private let lock = NSRecursiveLock()
+  var subscriptions: [CombineIdentifier: Subscription<Output, Failure>] = [:]
+
+  public func send(_ value: Output) {
+    self.lock.lock()
+    let subscriptions = self.subscriptions
+    self.lock.unlock()
+    subscriptions.forEach { _, subscription in
+      subscription.receive(value)
+    }
+  }
+
+  public func send(completion: Combine.Subscribers.Completion<Failure>) {
+    // ignore completion
+  }
+
+  public func send(subscription: Combine.Subscription) {
+    subscription.request(.unlimited)
+  }
+
+  public func receive<Subscriber: Combine.Subscriber>(
+    subscriber: Subscriber
+  ) where Failure == Subscriber.Failure, Output == Subscriber.Input {
+    let subscription = Subscription(
+      subscriber: subscriber,
+      cancelHandler: { [weak self] subscription in
+        guard let self = self else { return }
+        self.lock.lock(); defer { self.lock.unlock() }
+        self.subscriptions.removeValue(forKey: subscription.combineIdentifier)
+      }
+    )
+    subscriber.receive(subscription: subscription)
+    self.lock.lock()
+    self.subscriptions[subscription.combineIdentifier] = subscription
+    self.lock.unlock()
+  }
+}
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension ActionSubject {
+  final class Subscription<Output, Failure: Error>: Combine.Subscription {
+
+    typealias Output = Output
+    typealias Failure = Swift.Never
+
+    private let lock = NSRecursiveLock()
+    private let subscriber: Combine.AnySubscriber<Output, Failure>
+    private var demand: Combine.Subscribers.Demand = .none
+    private var cancelHandler: (Subscription<Output, Failure>) -> Void
+
+    init<Subscriber: Combine.Subscriber>(
+      subscriber: Subscriber,
+      cancelHandler: @escaping (Subscription<Output, Failure>) -> Void
+    ) where Output == Subscriber.Input, Failure == Subscriber.Failure {
+      self.subscriber = Combine.AnySubscriber<Output, Failure>(subscriber)
+      self.cancelHandler = cancelHandler
+    }
+
+    func request(_ demand: Combine.Subscribers.Demand) {
+      self.lock.lock(); defer { self.lock.unlock() }
+      self.demand += demand
+    }
+
+    func cancel() {
+      self.lock.lock(); defer { self.lock.unlock() }
+      self.cancelHandler(self)
+    }
+
+    func receive(_ value: Output) {
+      self.lock.lock(); defer { self.lock.unlock() }
+      guard self.demand > .none else { return }
+      self.demand -= 1
+      self.demand += self.subscriber.receive(value)
+    }
+  }
+}

--- a/Sources/ReactorKitCombine/DemandBuffer.swift
+++ b/Sources/ReactorKitCombine/DemandBuffer.swift
@@ -1,0 +1,149 @@
+//
+//  DemandBuffer.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/29.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Sources/Common/DemandBuffer.swift).
+//
+
+import Combine
+import class Foundation.NSRecursiveLock
+
+/// A buffer responsible for managing the demand of a downstream
+/// subscriber for an upstream publisher
+///
+/// It buffers values and completion events and forwards them dynamically
+/// according to the demand requested by the downstream
+///
+/// In a sense, the subscription only relays the requests for demand, as well
+/// the events emitted by the upstream — to this buffer, which manages
+/// the entire behavior and backpressure contract
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class DemandBuffer<S: Subscriber> {
+  private let lock = NSRecursiveLock()
+  private var buffer = [S.Input]()
+  private let subscriber: S
+  private var completion: Subscribers.Completion<S.Failure>?
+  private var demandState = Demand()
+
+  /// Initialize a new demand buffer for a provided downstream subscriber
+  ///
+  /// - parameter subscriber: The downstream subscriber demanding events
+  init(subscriber: S) {
+    self.subscriber = subscriber
+  }
+
+  /// Buffer an upstream value to later be forwarded to
+  /// the downstream subscriber, once it demands it
+  ///
+  /// - parameter value: Upstream value to buffer
+  ///
+  /// - returns: The demand fulfilled by the bufferr
+  func buffer(value: S.Input) -> Subscribers.Demand {
+    precondition(self.completion == nil, "How could a completed publisher sent values?! Beats me 🤷‍♂️")
+
+    switch self.demandState.requested {
+    case .unlimited:
+      return self.subscriber.receive(value)
+
+    default:
+      self.buffer.append(value)
+      return self.flush()
+    }
+  }
+
+  /// Complete the demand buffer with an upstream completion event
+  ///
+  /// This method will deplete the buffer immediately,
+  /// based on the currently accumulated demand, and relay the
+  /// completion event down as soon as demand is fulfilled
+  ///
+  /// - parameter completion: Completion event
+  func complete(completion: Subscribers.Completion<S.Failure>) {
+    precondition(self.completion == nil, "Completion have already occured, which is quite awkward 🥺")
+
+    self.completion = completion
+    _ = self.flush()
+  }
+
+  /// Signal to the buffer that the downstream requested new demand
+  ///
+  /// - note: The buffer will attempt to flush as many events rqeuested
+  ///         by the downstream at this point
+  func demand(_ demand: Subscribers.Demand) -> Subscribers.Demand {
+    self.flush(adding: demand)
+  }
+
+  /// Flush buffered events to the downstream based on the current
+  /// state of the downstream's demand
+  ///
+  /// - parameter newDemand: The new demand to add. If `nil`, the flush isn't the
+  ///                        result of an explicit demand change
+  ///
+  /// - note: After fulfilling the downstream's request, if completion
+  ///         has already occured, the buffer will be cleared and the
+  ///         completion event will be sent to the downstream subscriber
+  private func flush(adding newDemand: Subscribers.Demand? = nil) -> Subscribers.Demand {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+
+    if let newDemand = newDemand {
+      self.demandState.requested += newDemand
+    }
+
+    // If buffer isn't ready for flushing, return immediately
+    guard self.demandState.requested > 0 || newDemand == Subscribers.Demand.none else { return .none }
+
+    while !self.buffer.isEmpty && self.demandState.processed < self.demandState.requested {
+      self.demandState.requested += self.subscriber.receive(self.buffer.remove(at: 0))
+      self.demandState.processed += 1
+    }
+
+    if let completion = self.completion {
+      // Completion event was already sent
+      self.buffer = []
+      self.demandState = .init()
+      self.completion = nil
+      self.subscriber.receive(completion: completion)
+      return .none
+    }
+
+    let sentDemand = self.demandState.requested - self.demandState.sent
+    self.demandState.sent += sentDemand
+    return sentDemand
+  }
+}
+
+// MARK: - Private Helpers
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension DemandBuffer {
+  /// A model that tracks the downstream's
+  /// accumulated demand state
+  struct Demand {
+    var processed: Subscribers.Demand = .none
+    var requested: Subscribers.Demand = .none
+    var sent: Subscribers.Demand = .none
+  }
+}
+
+// MARK: - Internally-scoped helpers
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Subscription {
+  /// Reqeust demand if it's not empty
+  ///
+  /// - parameter demand: Requested demand
+  func requestIfNeeded(_ demand: Subscribers.Demand) {
+    guard demand > .none else { return }
+    self.request(demand)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Optional where Wrapped == Subscription {
+  /// Cancel the Optional subscription and nullify it
+  mutating func kill() {
+    self?.cancel()
+    self = nil
+  }
+}

--- a/Sources/ReactorKitCombine/IdentityEquatable.swift
+++ b/Sources/ReactorKitCombine/IdentityEquatable.swift
@@ -1,0 +1,15 @@
+//
+//  IdentityEquatable.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+public protocol IdentityEquatable: class, Equatable {
+}
+
+public extension IdentityEquatable {
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs === rhs
+  }
+}

--- a/Sources/ReactorKitCombine/IdentityHashable.swift
+++ b/Sources/ReactorKitCombine/IdentityHashable.swift
@@ -1,0 +1,15 @@
+//
+//  IdentityHashable.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+public protocol IdentityHashable: Hashable, IdentityEquatable {
+}
+
+public extension IdentityHashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self).hashValue)
+  }
+}

--- a/Sources/ReactorKitCombine/Reactor.swift
+++ b/Sources/ReactorKitCombine/Reactor.swift
@@ -1,0 +1,204 @@
+//
+//  Reactor.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/30.
+//
+
+import Combine
+import Foundation
+import WeakMapTable
+
+@available(*, obsoleted: 0, renamed: "Never")
+public typealias NoAction = Never
+
+@available(*, obsoleted: 0, renamed: "Never")
+public typealias NoMutation = Never
+
+/// A Reactor is an UI-independent layer which manages the state of a view. The foremost role of a
+/// reactor is to separate control flow from a view. Every view has its corresponding reactor and
+/// delegates all logic to its reactor. A reactor has no dependency to a view, so it can be easily
+/// tested.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public protocol Reactor: class {
+  /// An action represents user actions.
+  associatedtype Action
+
+  /// A mutation represents state changes.
+  associatedtype Mutation = Action
+
+  /// A State represents the current state of a view.
+  associatedtype State
+
+  associatedtype Scheduler: Combine.Scheduler = ImmediateScheduler
+
+  /// The action from the view. Bind user inputs to this subject.
+  var action: ActionSubject<Action> { get }
+
+  /// The initial state.
+  var initialState: State { get }
+
+  /// The current state. This value is changed just after the state stream emits a new state.
+  var currentState: State { get }
+
+  /// The state stream. Use this observable to observe the state changes.
+  var state: AnyPublisher<State, Never> { get }
+
+  /// A scheduler for reducing and observing the state stream. Defaults to `CurrentThreadScheduler`.
+  var scheduler: Scheduler { get }
+
+  /// Transforms the action. Use this function to combine with other observables. This method is
+  /// called once before the state stream is created.
+  func transform(action: AnyPublisher<Action, Never>) -> AnyPublisher<Action, Never>
+
+  /// Commits mutation from the action. This is the best place to perform side-effects such as
+  /// async tasks.
+  func mutate(action: Action) -> AnyPublisher<Mutation, Never>
+
+  /// Transforms the mutation stream. Implement this method to transform or combine with other
+  /// observables. This method is called once before the state stream is created.
+  func transform(mutation: AnyPublisher<Mutation, Never>) -> AnyPublisher<Mutation, Never>
+
+  /// Generates a new state with the previous state and the action. It should be purely functional
+  /// so it should not perform any side-effects here. This method is called every time when the
+  /// mutation is committed.
+  func reduce(state: State, mutation: Mutation) -> State
+
+  /// Transforms the state stream. Use this function to perform side-effects such as logging. This
+  /// method is called once after the state stream is created.
+  func transform(state: AnyPublisher<State, Never>) -> AnyPublisher<State, Never>
+}
+
+
+// MARK: - Map Tables
+
+private typealias AnyReactor = AnyObject
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private enum MapTables {
+  static let action = WeakMapTable<AnyReactor, AnyObject>()
+  static let currentState = WeakMapTable<AnyReactor, Any>()
+  static let state = WeakMapTable<AnyReactor, AnyObject>()
+  static let cancellables = WeakMapTable<AnyReactor, Set<AnyCancellable>>()
+  static let isStubEnabled = WeakMapTable<AnyReactor, Bool>()
+  static let stub = WeakMapTable<AnyReactor, AnyObject>()
+}
+
+
+// MARK: - Default Implementations
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Reactor {
+  private var _action: ActionSubject<Action> {
+    if self.isStubEnabled {
+      return self.stub.action
+    } else {
+      return MapTables.action.forceCastedValue(forKey: self, default: .init())
+    }
+  }
+  public var action: ActionSubject<Action> {
+    // Creates a state stream automatically
+    _ = self._state
+
+    // It seems that Swift has a bug in associated object when subclassing a generic class. This is
+    // a temporary solution to bypass the bug. See #30 for details.
+    return self._action
+  }
+
+  public internal(set) var currentState: State {
+    get { return MapTables.currentState.forceCastedValue(forKey: self, default: self.initialState) }
+    set { MapTables.currentState.setValue(newValue, forKey: self) }
+  }
+
+  private var _state: AnyPublisher<State, Never> {
+    if self.isStubEnabled {
+      return self.stub.state.eraseToAnyPublisher()
+    } else {
+      return MapTables.state.forceCastedValue(forKey: self, default: self.createStateStream())
+    }
+  }
+  public var state: AnyPublisher<State, Never> {
+    // It seems that Swift has a bug in associated object when subclassing a generic class. This is
+    // a temporary solution to bypass the bug. See #30 for details.
+    return self._state
+  }
+
+  public var scheduler: ImmediateScheduler {
+    return ImmediateScheduler.shared
+  }
+
+  fileprivate var cancellables: Set<AnyCancellable> {
+    get { return MapTables.cancellables.value(forKey: self, default: []) }
+    set { MapTables.cancellables.setValue(newValue, forKey: self) }
+  }
+
+  public func createStateStream() -> AnyPublisher<State, Never> {
+    let action = self._action.receive(on: self.scheduler).eraseToAnyPublisher()
+    let transformedAction = self.transform(action: action)
+    let mutation = transformedAction
+      .flatMap { [weak self] action -> AnyPublisher<Mutation, Never> in
+        guard let self = self else { return Empty().eraseToAnyPublisher() }
+        return self.mutate(action: action).catch { _ in Empty() }.eraseToAnyPublisher()
+      }
+      .eraseToAnyPublisher()
+    let transformedMutation = self.transform(mutation: mutation)
+    let state = transformedMutation
+      .scan(self.initialState) { [weak self] state, mutation -> State in
+        guard let self = self else { return state }
+        return self.reduce(state: state, mutation: mutation)
+      }
+      .catch { _ in Empty<State, Never>() }
+      .prepend(self.initialState)
+      .eraseToAnyPublisher()
+    let transformedState = self.transform(state: state)
+      .handleEvents(receiveOutput: { [weak self] state in
+        self?.currentState = state
+      })
+      .replay(1)
+      .autoconnect()
+    transformedState.sink(receiveValue: { _ in }).store(in: &self.cancellables)
+    return transformedState.eraseToAnyPublisher()
+  }
+
+  public func transform(action: AnyPublisher<Action, Never>) -> AnyPublisher<Action, Never> {
+    return action
+  }
+
+  public func mutate(action: Action) -> AnyPublisher<Mutation, Never> {
+    return Empty().eraseToAnyPublisher()
+  }
+
+  public func transform(mutation: AnyPublisher<Mutation, Never>) -> AnyPublisher<Mutation, Never> {
+    return mutation
+  }
+
+  public func reduce(state: State, mutation: Mutation) -> State {
+    return state
+  }
+
+  public func transform(state: AnyPublisher<State, Never>) -> AnyPublisher<State, Never> {
+    return state
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Reactor where Action == Mutation {
+  public func mutate(action: Action) -> AnyPublisher<Mutation, Never> {
+    return Just(action).eraseToAnyPublisher()
+  }
+}
+
+
+// MARK: - Stub
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Reactor {
+  public var isStubEnabled: Bool {
+    get { return MapTables.isStubEnabled.value(forKey: self, default: false) }
+    set { MapTables.isStubEnabled.setValue(newValue, forKey: self) }
+  }
+
+  public var stub: Stub<Self> {
+    return MapTables.stub.forceCastedValue(forKey: self, default: .init(reactor: self, cancellables: self.cancellables))
+  }
+}

--- a/Sources/ReactorKitCombine/Relay.swift
+++ b/Sources/ReactorKitCombine/Relay.swift
@@ -1,0 +1,49 @@
+//
+//  Relay.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/29.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Sources/Relays/Relay.swift).
+//
+
+import Combine
+
+/// A publisher that exposes a method for outside callers to publish values.
+/// It is identical to a `Subject`, but it cannot publish a finish event (until it's deallocated).
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public protocol Relay: Publisher where Failure == Never {
+  associatedtype Output
+
+  /// Relays a value to the subscriber.
+  ///
+  /// - Parameter value: The value to send.
+  func accept(_ value: Output)
+
+  /// Attaches the specified publisher to this relay.
+  ///
+  /// - parameter publisher: An infallible publisher with the relay's Output type
+  ///
+  /// - returns: `AnyCancellable`
+  func subscribe<P: Publisher>(_ publisher: P) -> AnyCancellable where P.Failure == Failure, P.Output == Output
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Publisher where Failure == Never {
+  /// Attaches the specified relay to this publisher.
+  ///
+  /// - parameter relay: Relay to attach to this publisher
+  ///
+  /// - returns: `AnyCancellable`
+  func subscribe<R: Relay>(_ relay: R) -> AnyCancellable where R.Output == Output {
+    relay.subscribe(self)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension Relay where Output == Void {
+  /// Relay a void to the subscriber.
+  func accept() {
+    self.accept(())
+  }
+}

--- a/Sources/ReactorKitCombine/Replay.swift
+++ b/Sources/ReactorKitCombine/Replay.swift
@@ -1,0 +1,15 @@
+//
+//  Replay.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/29.
+//
+
+import Combine
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension Publisher {
+  func replay(_ bufferSize: Int) -> Publishers.Multicast<Self, ReplaySubject<Output, Failure>> {
+    return self.multicast(subject: ReplaySubject(bufferSize: bufferSize))
+  }
+}

--- a/Sources/ReactorKitCombine/ReplaySubject.swift
+++ b/Sources/ReactorKitCombine/ReplaySubject.swift
@@ -1,0 +1,121 @@
+//
+//  ReplaySubject.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/29.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Sources/Subjects/ReplaySubject.swift).
+//
+
+import Combine
+
+/// A `ReplaySubject` is a subject that can buffer one or more values. It stores value events, up to its `bufferSize` in a
+/// first-in-first-out manner and then replays it to
+/// future subscribers and also forwards completion events.
+///
+/// The implementation borrows heavily from [Entwine’s](https://github.com/tcldr/Entwine/blob/b839c9fcc7466878d6a823677ce608da998b95b9/Sources/Entwine/Operators/ReplaySubject.swift).
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public final class ReplaySubject<Output, Failure: Error>: Subject {
+  public typealias Output = Output
+  public typealias Failure = Failure
+
+  private let bufferSize: Int
+  private var buffer = [Output]()
+
+  // Keeping track of all live subscriptions, so `send` events can be forwarded to them.
+  private var subscriptions = [Subscription<AnySubscriber<Output, Failure>>]()
+
+  private var completion: Subscribers.Completion<Failure>?
+  private var isActive: Bool { self.completion == nil }
+
+  /// Create a `ReplaySubject`, buffering up to `bufferSize` values and replaying them to new subscribers
+  /// - Parameter bufferSize: The maximum number of value events to buffer and replay to all future subscribers.
+  public init(bufferSize: Int) {
+    self.bufferSize = bufferSize
+  }
+
+  public func send(_ value: Output) {
+    guard self.isActive else { return }
+
+    self.buffer.append(value)
+
+    if self.buffer.count > self.bufferSize {
+      self.buffer.removeFirst()
+    }
+
+    self.subscriptions.forEach { $0.forwardValueToBuffer(value) }
+  }
+
+  public func send(completion: Subscribers.Completion<Failure>) {
+    guard self.isActive else { return }
+
+    self.completion = completion
+
+    self.subscriptions.forEach { $0.forwardCompletionToBuffer(completion) }
+  }
+
+  public func send(subscription: Combine.Subscription) {
+    subscription.request(.unlimited)
+  }
+
+  public func receive<Subscriber: Combine.Subscriber>(subscriber: Subscriber) where Failure == Subscriber.Failure, Output == Subscriber.Input {
+    let subscriberIdentifier = subscriber.combineIdentifier
+
+    let subscription = Subscription(downstream: AnySubscriber(subscriber)) { [weak self] in
+      let isEqualToSubscriber: (Subscription<AnySubscriber<Output, Failure>>) -> Bool = {
+        $0.innerSubscriberIdentifier == subscriberIdentifier
+      }
+      guard let subscriptionIndex = self?.subscriptions.firstIndex(where: isEqualToSubscriber) else { return }
+
+      self?.subscriptions.remove(at: subscriptionIndex)
+    }
+
+    self.subscriptions.append(subscription)
+
+    subscriber.receive(subscription: subscription)
+    subscription.replay(self.buffer, completion: self.completion)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension ReplaySubject {
+  final class Subscription<Downstream: Subscriber>: Combine.Subscription where Output == Downstream.Input, Failure == Downstream.Failure {
+    private var demandBuffer: DemandBuffer<Downstream>?
+    private var cancellationHandler: (() -> Void)?
+
+    fileprivate let innerSubscriberIdentifier: CombineIdentifier
+
+    init(downstream: Downstream, cancellationHandler: (() -> Void)?) {
+      self.demandBuffer = DemandBuffer(subscriber: downstream)
+      self.innerSubscriberIdentifier = downstream.combineIdentifier
+      self.cancellationHandler = cancellationHandler
+    }
+
+    func replay(_ buffer: [Output], completion: Subscribers.Completion<Failure>?) {
+      buffer.forEach(self.forwardValueToBuffer)
+
+      if let completion = completion {
+        self.forwardCompletionToBuffer(completion)
+      }
+    }
+
+    func forwardValueToBuffer(_ value: Output) {
+      _ = self.demandBuffer?.buffer(value: value)
+    }
+
+    func forwardCompletionToBuffer(_ completion: Subscribers.Completion<Failure>) {
+      self.demandBuffer?.complete(completion: completion)
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+      _ = self.demandBuffer?.demand(demand)
+    }
+
+    func cancel() {
+      self.cancellationHandler?()
+      self.cancellationHandler = nil
+
+      self.demandBuffer = nil
+    }
+  }
+}

--- a/Sources/ReactorKitCombine/ReplaySubject.swift
+++ b/Sources/ReactorKitCombine/ReplaySubject.swift
@@ -15,9 +15,9 @@ import Combine
 ///
 /// The implementation borrows heavily from [Entwine’s](https://github.com/tcldr/Entwine/blob/b839c9fcc7466878d6a823677ce608da998b95b9/Sources/Entwine/Operators/ReplaySubject.swift).
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public final class ReplaySubject<Output, Failure: Error>: Subject {
-  public typealias Output = Output
-  public typealias Failure = Failure
+final class ReplaySubject<Output, Failure: Error>: Subject {
+  typealias Output = Output
+  typealias Failure = Failure
 
   private let bufferSize: Int
   private var buffer = [Output]()
@@ -30,11 +30,11 @@ public final class ReplaySubject<Output, Failure: Error>: Subject {
 
   /// Create a `ReplaySubject`, buffering up to `bufferSize` values and replaying them to new subscribers
   /// - Parameter bufferSize: The maximum number of value events to buffer and replay to all future subscribers.
-  public init(bufferSize: Int) {
+  init(bufferSize: Int) {
     self.bufferSize = bufferSize
   }
 
-  public func send(_ value: Output) {
+  func send(_ value: Output) {
     guard self.isActive else { return }
 
     self.buffer.append(value)
@@ -46,7 +46,7 @@ public final class ReplaySubject<Output, Failure: Error>: Subject {
     self.subscriptions.forEach { $0.forwardValueToBuffer(value) }
   }
 
-  public func send(completion: Subscribers.Completion<Failure>) {
+  func send(completion: Subscribers.Completion<Failure>) {
     guard self.isActive else { return }
 
     self.completion = completion
@@ -54,11 +54,11 @@ public final class ReplaySubject<Output, Failure: Error>: Subject {
     self.subscriptions.forEach { $0.forwardCompletionToBuffer(completion) }
   }
 
-  public func send(subscription: Combine.Subscription) {
+  func send(subscription: Combine.Subscription) {
     subscription.request(.unlimited)
   }
 
-  public func receive<Subscriber: Combine.Subscriber>(subscriber: Subscriber) where Failure == Subscriber.Failure, Output == Subscriber.Input {
+  func receive<Subscriber: Combine.Subscriber>(subscriber: Subscriber) where Failure == Subscriber.Failure, Output == Subscriber.Input {
     let subscriberIdentifier = subscriber.combineIdentifier
 
     let subscription = Subscription(downstream: AnySubscriber(subscriber)) { [weak self] in

--- a/Sources/ReactorKitCombine/Sink.swift
+++ b/Sources/ReactorKitCombine/Sink.swift
@@ -1,0 +1,102 @@
+//
+//  Sink.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/29.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Sources/Common/Sink.swift).
+//
+
+import Combine
+
+/// A generic sink using an underlying demand buffer to balance
+/// the demand of a downstream subscriber for the events of an
+/// upstream publisher
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+class Sink<Upstream: Publisher, Downstream: Subscriber>: Subscriber {
+  typealias TransformFailure = (Upstream.Failure) -> Downstream.Failure?
+  typealias TransformOutput = (Upstream.Output) -> Downstream.Input?
+
+  private(set) var buffer: DemandBuffer<Downstream>
+  private var upstreamSubscription: Subscription?
+  private let transformOutput: TransformOutput?
+  private let transformFailure: TransformFailure?
+
+  /// Initialize a new sink subscribing to the upstream publisher and
+  /// fulfilling the demand of the downstream subscriber using a backpresurre
+  /// demand-maintaining buffer.
+  ///
+  /// - parameter upstream: The upstream publisher
+  /// - parameter downstream: The downstream subscriber
+  /// - parameter transformOutput: Transform the upstream publisher's output type to the downstream's input type
+  /// - parameter transformFailure: Transform the upstream failure type to the downstream's failure type
+  ///
+  /// - note: You **must** provide the two transformation functions above if you're using
+  ///         the default `Sink` implementation. Otherwise, you must subclass `Sink` with your own
+  ///         publisher's sink and manage the buffer accordingly.
+  init(upstream: Upstream,
+       downstream: Downstream,
+       transformOutput: TransformOutput? = nil,
+       transformFailure: TransformFailure? = nil) {
+    self.buffer = DemandBuffer(subscriber: downstream)
+    self.transformOutput = transformOutput
+    self.transformFailure = transformFailure
+    upstream.subscribe(self)
+  }
+
+  func demand(_ demand: Subscribers.Demand) {
+    let newDemand = self.buffer.demand(demand)
+    self.upstreamSubscription?.requestIfNeeded(newDemand)
+  }
+
+  func receive(subscription: Subscription) {
+    self.upstreamSubscription = subscription
+  }
+
+  func receive(_ input: Upstream.Output) -> Subscribers.Demand {
+    guard let transform = self.transformOutput else {
+      fatalError(
+        """
+        ❌ Missing output transformation
+        =========================
+        You must either:
+            - Provide a transformation function from the upstream's output to the downstream's input; or
+            - Subclass `Sink` with your own publisher's Sink and manage the buffer yourself
+        """
+      )
+    }
+
+    guard let input = transform(input) else { return .none }
+    return self.buffer.buffer(value: input)
+  }
+
+  func receive(completion: Subscribers.Completion<Upstream.Failure>) {
+    switch completion {
+    case .finished:
+      self.buffer.complete(completion: .finished)
+    case .failure(let error):
+      guard let transform = self.transformFailure else {
+        fatalError(
+          """
+          ❌ Missing failure transformation
+          =========================
+          You must either:
+              - Provide a transformation function from the upstream's failure to the downstream's failuer; or
+              - Subclass `Sink` with your own publisher's Sink and manage the buffer yourself
+          """
+        )
+      }
+
+      guard let error = transform(error) else { return }
+      self.buffer.complete(completion: .failure(error))
+    }
+
+    self.cancelUpstream()
+  }
+
+  func cancelUpstream() {
+    self.upstreamSubscription.kill()
+  }
+
+  deinit { self.cancelUpstream() }
+}

--- a/Sources/ReactorKitCombine/StateRelay.swift
+++ b/Sources/ReactorKitCombine/StateRelay.swift
@@ -1,0 +1,106 @@
+//
+//  StateRelay.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/07/06.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Sources/Relays/CurrentValueRelay.swift).
+//
+
+import Combine
+
+/// A relay that wraps a single value and publishes a new element whenever the value changes.
+///
+/// Unlike its subject-counterpart, it may only accept values, and only sends a finishing event on deallocation.
+/// It cannot send a failure event.
+///
+/// - note: Unlike PassthroughRelay, CurrentValueRelay maintains a buffer of the most recently published value.
+///
+/// StateRelay is a wrapper for `BehaviorSubject`.
+///
+/// Unlike `BehaviorSubject` it can't terminate with error or completed.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public class StateRelay<Output>: Relay {
+
+  private let storage: CurrentValueSubject<Output, Never>
+  private var subscriptions: [Subscription<CurrentValueSubject<Output, Never>, AnySubscriber<Output, Never>>] = []
+
+  public var value: Output {
+    get { return self.storage.value }
+    set { self.accept(newValue) }
+  }
+
+  /// Create a new relay
+  ///
+  /// - parameter value: Initial value for the relay
+  public init(_ value: Output) {
+    self.storage = .init(value)
+  }
+
+  /// Relay a value to downstream subscribers
+  ///
+  /// - parameter value: A new value
+  public func accept(_ value: Output) {
+    self.storage.send(value)
+  }
+
+  public func receive<S: Subscriber>(subscriber: S) where Output == S.Input, Never == S.Failure {
+    let subscription = Subscription(upstream: self.storage, downstream: AnySubscriber(subscriber))
+    self.subscriptions.append(subscription)
+    subscriber.receive(subscription: subscription)
+  }
+
+  public func subscribe<P: Publisher>(_ publisher: P) -> AnyCancellable where Output == P.Output, P.Failure == Never {
+    publisher.subscribe(self.storage)
+  }
+
+  deinit {
+    // Send a finished event upon dealloation
+    self.subscriptions.forEach { $0.forceFinish() }
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension StateRelay {
+  class Subscription<Upstream: Publisher, Downstream: Subscriber>: Combine.Subscription where Upstream.Output == Downstream.Input, Upstream.Failure == Downstream.Failure {
+
+    private var sink: Sink<Upstream, Downstream>?
+    var shouldForwardCompletion: Bool {
+      get { self.sink?.shouldForwardCompletion ?? false }
+      set { self.sink?.shouldForwardCompletion = newValue }
+    }
+
+    init(upstream: Upstream,
+         downstream: Downstream) {
+      self.sink = Sink(
+        upstream: upstream,
+        downstream: downstream,
+        transformOutput: { $0 }
+      )
+    }
+
+    func forceFinish() {
+      self.sink?.shouldForwardCompletion = true
+      self.sink?.receive(completion: .finished)
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+      self.sink?.demand(demand)
+    }
+
+    func cancel() {
+      self.sink = nil
+    }
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension StateRelay {
+  class Sink<Upstream: Publisher, Downstream: Subscriber>: ReactorKitCombine.Sink<Upstream, Downstream> {
+    var shouldForwardCompletion = false
+    override func receive(completion: Subscribers.Completion<Upstream.Failure>) {
+      guard self.shouldForwardCompletion else { return }
+      super.receive(completion: completion)
+    }
+  }
+}

--- a/Sources/ReactorKitCombine/Stub.swift
+++ b/Sources/ReactorKitCombine/Stub.swift
@@ -1,0 +1,35 @@
+//
+//  Stub.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/29.
+//
+
+import Combine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public class Stub<Reactor: ReactorKitCombine.Reactor> {
+  private unowned var reactor: Reactor
+  private var cancellables: Set<AnyCancellable>
+
+  public let state: StateRelay<Reactor.State>
+  public let action: ActionSubject<Reactor.Action>
+  public private(set) var actions: [Reactor.Action] = []
+
+  public init(reactor: Reactor, cancellables: Set<AnyCancellable>) {
+    self.reactor = reactor
+    self.cancellables = cancellables
+    self.state = .init(reactor.initialState)
+    self.state
+      .sink(receiveValue: { [weak reactor] state in
+        reactor?.currentState = state
+      })
+      .store(in: &self.cancellables)
+    self.action = .init()
+    self.action
+      .sink(receiveValue: { [weak self] action in
+        self?.actions.append(action)
+      })
+      .store(in: &self.cancellables)
+  }
+}

--- a/Sources/ReactorKitCombine/View.swift
+++ b/Sources/ReactorKitCombine/View.swift
@@ -1,0 +1,67 @@
+//
+//  View.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+#if !os(Linux)
+import Combine
+import WeakMapTable
+
+private typealias AnyView = AnyObject
+private enum MapTables {
+  static let reactor = WeakMapTable<AnyView, Any>()
+}
+
+/// A View displays data. A view controller and a cell are treated as a view. The view binds user
+/// inputs to the action stream and binds the view states to each UI component. There's no business
+/// logic in a view layer. A view just defines how to map the action stream and the state stream.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public protocol View: class {
+  associatedtype Reactor: ReactorKitCombine.Reactor
+
+  /// A dispose bag. It is disposed each time the `reactor` is assigned.
+  var cancellables: Set<AnyCancellable> { get set }
+
+  /// A view's reactor. `bind(reactor:)` gets called when the new value is assigned to this property.
+  var reactor: Reactor? { get set }
+
+  /// Creates Combine bindings. This method is called each time the `reactor` is assigned.
+  ///
+  /// Here is a typical implementation example:
+  ///
+  /// ```
+  /// func bind(reactor: MyReactor) {
+  ///   // Action
+  ///   increaseButton.rx.tap
+  ///     .assign(to: Reactor.Action.increase)
+  ///     .disposed(by: disposeBag)
+  ///
+  ///   // State
+  ///   reactor.state.map { $0.count }
+  ///     .assign(to: countLabel.rx.text)
+  ///     .disposed(by: disposeBag)
+  /// }
+  /// ```
+  ///
+  /// - warning: It's not recommended to call this method directly.
+  func bind(reactor: Reactor)
+}
+
+// MARK: - Default Implementations
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension View {
+  public var reactor: Reactor? {
+    get { return MapTables.reactor.value(forKey: self) as? Reactor }
+    set {
+      MapTables.reactor.setValue(newValue, forKey: self)
+      self.cancellables = []
+      if let reactor = newValue {
+        self.bind(reactor: reactor)
+      }
+    }
+  }
+}
+#endif

--- a/Tests/ReactorKitCombineTests/ActionSubjectTests.swift
+++ b/Tests/ReactorKitCombineTests/ActionSubjectTests.swift
@@ -1,0 +1,73 @@
+//
+//  ActionSubjectTests.swift
+//  ReactorKitCombine
+//
+//  Created by tokijh on 2020/06/25.
+//
+
+import XCTest
+
+import Combine
+@testable import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class ActionSubjectTests: XCTestCase {
+  func testObserversCount_disposable() {
+    let subject = ActionSubject<Int>()
+    let cancellable1 = subject.sink(receiveValue: { _ in })
+    XCTAssertEqual(subject.subscriptions.count, 1)
+    let cancellable2 = subject.sink(receiveValue: { _ in })
+    XCTAssertEqual(subject.subscriptions.count, 2)
+    cancellable1.cancel()
+    XCTAssertEqual(subject.subscriptions.count, 1)
+    cancellable2.cancel()
+    XCTAssertEqual(subject.subscriptions.count, 0)
+  }
+
+  func testEmitNexts() {
+    // given
+    let subject = ActionSubject<Int>()
+
+    var cancellables: Set<AnyCancellable> = []
+    var latestValue: Int?
+    subject.sink { latestValue = $0 }.store(in: &cancellables)
+
+    // when & then
+    subject.send(100)
+    XCTAssertEqual(latestValue, 100)
+
+    subject.send(200)
+    XCTAssertEqual(latestValue, 200)
+
+    subject.send(300)
+    XCTAssertEqual(latestValue, 300)
+  }
+
+  func testIgnoreCompleted() {
+    // given
+    let subject = ActionSubject<Int>()
+
+    var cancellables: Set<AnyCancellable> = []
+    var receivedCompletions: [Subscribers.Completion<Never>] = []
+    var receivedValues: [Int] = []
+    subject
+      .sink(
+        receiveCompletion: { receivedCompletions.append($0) },
+        receiveValue: { receivedValues.append($0) }
+      )
+      .store(in: &cancellables)
+
+    // when & then
+    subject.send(100)
+    XCTAssertEqual(receivedCompletions.count, 0)
+    XCTAssertEqual(receivedValues, [100])
+
+    subject.send(completion: .finished)
+    XCTAssertEqual(receivedCompletions.count, 0)
+    XCTAssertEqual(receivedValues, [100])
+
+    subject.send(200)
+    XCTAssertEqual(receivedCompletions.count, 0)
+    XCTAssertEqual(receivedValues, [100, 200])
+  }
+}

--- a/Tests/ReactorKitCombineTests/AnyPublisher+Create.swift
+++ b/Tests/ReactorKitCombineTests/AnyPublisher+Create.swift
@@ -1,0 +1,184 @@
+//
+//  AnyPublisher+Create.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/06/30.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Sources/Operators/Create.swift).
+//
+
+import Combine
+import Foundation
+@testable import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension AnyPublisher {
+  /// Create a publisher which accepts a closure with a subscriber argument,
+  /// to which you can dynamically send value or completion events.
+  ///
+  /// You should return a `Cancelable`-conforming object from the closure in
+  /// which you can define any cleanup actions to execute when the pubilsher
+  /// completes or the subscription to the publisher is canceled.
+  ///
+  /// - parameter factory: A factory with a closure to which you can
+  ///                      dynamically send value or completion events.
+  ///                      You should return a `Cancelable`-conforming object
+  ///                      from it to encapsulate any cleanup-logic for your work.
+  ///
+  /// An example usage could look as follows:
+  ///
+  ///    ```
+  ///    AnyPublisher<String, MyError>.create { subscriber in
+  ///        // Values
+  ///        subscriber.send("Hello")
+  ///        subscriber.send("World!")
+  ///
+  ///        // Complete with error
+  ///        subscriber.send(completion: .failure(MyError.someError))
+  ///
+  ///        // Or, complete successfully
+  ///        subscriber.send(completion: .finished)
+  ///
+  ///        return AnyCancellable {
+  ///          // Perform clean-up
+  ///        }
+  ///    }
+  ///
+  init(_ factory: @escaping Publishers.Create<Output, Failure>.SubscriberHandler) {
+    self = Publishers.Create(factory: factory).eraseToAnyPublisher()
+  }
+
+  /// Create a publisher which accepts a closure with a subscriber argument,
+  /// to which you can dynamically send value or completion events.
+  ///
+  /// You should return a `Cancelable`-conforming object from the closure in
+  /// which you can define any cleanup actions to execute when the pubilsher
+  /// completes or the subscription to the publisher is canceled.
+  ///
+  /// - parameter factory: A factory with a closure to which you can
+  ///                      dynamically send value or completion events.
+  ///                      You should return a `Cancelable`-conforming object
+  ///                      from it to encapsulate any cleanup-logic for your work.
+  ///
+  /// An example usage could look as follows:
+  ///
+  ///    ```
+  ///    AnyPublisher<String, MyError>.create { subscriber in
+  ///        // Values
+  ///        subscriber.send("Hello")
+  ///        subscriber.send("World!")
+  ///
+  ///        // Complete with error
+  ///        subscriber.send(completion: .failure(MyError.someError))
+  ///
+  ///        // Or, complete successfully
+  ///        subscriber.send(completion: .finished)
+  ///
+  ///        return AnyCancellable {
+  ///          // Perform clean-up
+  ///        }
+  ///    }
+  ///
+  static func create(
+    _ factory: @escaping Publishers.Create<Output, Failure>.SubscriberHandler
+  ) -> AnyPublisher<Output, Failure> {
+    AnyPublisher(factory)
+  }
+}
+
+// MARK: - Publisher
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publishers {
+  /// A publisher which accepts a closure with a subscriber argument,
+  /// to which you can dynamically send value or completion events.
+  ///
+  /// You should return a `Cancelable`-conforming object from the closure in
+  /// which you can define any cleanup actions to execute when the pubilsher
+  /// completes or the subscription to the publisher is canceled.
+  struct Create<Output, Failure: Swift.Error>: Publisher {
+    public typealias SubscriberHandler = (Subscriber) -> Cancellable
+    private let factory: SubscriberHandler
+
+    /// Initialize the publisher with a provided factory
+    ///
+    /// - parameter factory: A factory with a closure to which you can
+    ///                      dynamically push value or completion events
+    public init(factory: @escaping SubscriberHandler) {
+      self.factory = factory
+    }
+
+    public func receive<S: Combine.Subscriber>(subscriber: S) where Failure == S.Failure, Output == S.Input {
+      subscriber.receive(subscription: Subscription(factory: self.factory, downstream: subscriber))
+    }
+  }
+}
+
+// MARK: - Subscription
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension Publishers.Create {
+  class Subscription<Downstream: Combine.Subscriber>: Combine.Subscription where Output == Downstream.Input, Failure == Downstream.Failure {
+    private let buffer: DemandBuffer<Downstream>
+    private var cancelable: Cancellable?
+
+    init(
+      factory: @escaping SubscriberHandler,
+      downstream: Downstream
+    ) {
+      self.buffer = DemandBuffer(subscriber: downstream)
+
+      let subscriber = Subscriber(
+        onValue: { [weak self] in _ = self?.buffer.buffer(value: $0) },
+        onCompletion: { [weak self] in self?.buffer.complete(completion: $0) }
+      )
+
+      self.cancelable = factory(subscriber)
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+      _ = self.buffer.demand(demand)
+    }
+
+    func cancel() {
+      self.cancelable?.cancel()
+    }
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publishers.Create.Subscription: CustomStringConvertible {
+  var description: String {
+    return "Create.Subscription<\(Output.self), \(Failure.self)>"
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publishers.Create {
+  struct Subscriber {
+    private let onValue: (Output) -> Void
+    private let onCompletion: (Subscribers.Completion<Failure>) -> Void
+
+    fileprivate init(
+      onValue: @escaping (Output) -> Void,
+      onCompletion: @escaping (Subscribers.Completion<Failure>) -> Void
+    ) {
+      self.onValue = onValue
+      self.onCompletion = onCompletion
+    }
+
+    /// Sends a value to the subscriber.
+    ///
+    /// - Parameter value: The value to send.
+    public func send(_ input: Output) {
+      self.onValue(input)
+    }
+
+    /// Sends a completion event to the subscriber.
+    ///
+    /// - Parameter completion: A `Completion` instance which indicates whether publishing has finished normally or failed with an error.
+    public func send(completion: Subscribers.Completion<Failure>) {
+      self.onCompletion(completion)
+    }
+  }
+}

--- a/Tests/ReactorKitCombineTests/AnyPublisher+CreateTests.swift
+++ b/Tests/ReactorKitCombineTests/AnyPublisher+CreateTests.swift
@@ -1,0 +1,168 @@
+//
+//  AnyPublisher+CreateTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/07/07.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Tests/Create.swift).
+//
+
+import XCTest
+
+import Combine
+@testable import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class CreateTests: XCTestCase {
+  var subscription: AnyCancellable!
+  enum MyError: Swift.Error {
+    case failure
+  }
+
+  private var completion: Subscribers.Completion<CreateTests.MyError>?
+  private var values = [String]()
+  private var canceled = false
+  private let allValues = ["Hello", "World", "What's", "Up?"]
+
+  override func setUp() {
+    canceled = false
+    values = []
+    completion = nil
+  }
+
+  func testUnlimitedDemandFinished() {
+    let expect = expectation(description: "4 values and finished event")
+    let subscriber = makeSubscriber(demand: .unlimited,
+                                    expectation: expect)
+    let publisher = makePublisher(fail: false)
+
+    publisher.subscribe(subscriber)
+    wait(for: [expect], timeout: 1)
+
+    XCTAssertEqual(completion, .finished)
+    XCTAssertTrue(canceled)
+    XCTAssertEqual(values, allValues)
+  }
+
+  func testLimitedDemandFinished() {
+    let expect = expectation(description: "2 values and finished event")
+    let subscriber = makeSubscriber(demand: .max(2),
+                                    expectation: expect)
+
+    let publisher = AnyPublisher<String, MyError> { subscriber in
+      self.allValues.forEach { subscriber.send($0) }
+      subscriber.send(completion: .finished)
+
+      return AnyCancellable { [weak self] in
+        self?.canceled = true
+      }
+    }
+
+    publisher.subscribe(subscriber)
+    wait(for: [expect], timeout: 1)
+
+    XCTAssertEqual(completion, .finished)
+    XCTAssertTrue(canceled)
+    XCTAssertEqual(values, Array(allValues.prefix(2)))
+  }
+
+  func testNoDemandFinished() {
+    let expect = expectation(description: "no values and finished event")
+    let subscriber = makeSubscriber(demand: .none,
+                                    expectation: expect)
+    let publisher = makePublisher(fail: false)
+
+    publisher.subscribe(subscriber)
+    wait(for: [expect], timeout: 1)
+
+    XCTAssertEqual(completion, .finished)
+    XCTAssertTrue(canceled)
+    XCTAssertTrue(values.isEmpty)
+  }
+
+  func testUnlimitedDemandError() {
+    let expect = expectation(description: "4 values and error event")
+    let subscriber = makeSubscriber(demand: .unlimited,
+                                    expectation: expect)
+    let publisher = makePublisher(fail: true)
+
+    publisher.subscribe(subscriber)
+    wait(for: [expect], timeout: 1)
+
+    XCTAssertEqual(completion, .failure(MyError.failure))
+    XCTAssertTrue(canceled)
+    XCTAssertEqual(values, allValues)
+  }
+
+  func testLimitedDemandError() {
+    let expect = expectation(description: "2 values and error event")
+    let subscriber = makeSubscriber(demand: .max(2),
+                                    expectation: expect)
+    let publisher = makePublisher(fail: true)
+
+    publisher.subscribe(subscriber)
+    wait(for: [expect], timeout: 1)
+
+    XCTAssertEqual(completion, .failure(MyError.failure))
+    XCTAssertTrue(canceled)
+    XCTAssertEqual(values, Array(allValues.prefix(2)))
+  }
+
+  func testNoDemandError() {
+    let expect = expectation(description: "no values and error event")
+    let subscriber = makeSubscriber(demand: .none,
+                                    expectation: expect)
+    let publisher = makePublisher(fail: true)
+
+    publisher.subscribe(subscriber)
+    wait(for: [expect], timeout: 1)
+
+    XCTAssertEqual(completion, .failure(MyError.failure))
+    XCTAssertTrue(canceled)
+    XCTAssertTrue(values.isEmpty)
+  }
+
+  var cancelable: Cancellable?
+  func testManualCancelation() {
+    let publisher = AnyPublisher<String, Never>.create { _ in
+      return AnyCancellable { [weak self] in self?.canceled = true }
+    }
+
+    cancelable = publisher.sink { _ in }
+    XCTAssertFalse(canceled)
+    cancelable?.cancel()
+    XCTAssertTrue(canceled)
+  }
+}
+
+// MARK: - Private Helpers
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private extension CreateTests {
+  func makePublisher(fail: Bool = false) -> AnyPublisher<String, MyError> {
+    AnyPublisher<String, MyError>.create { subscriber in
+      self.allValues.forEach { subscriber.send($0) }
+      subscriber.send(completion: fail ? .failure(MyError.failure) : .finished)
+
+      return AnyCancellable { [weak self] in
+        self?.canceled = true
+      }
+    }
+  }
+
+  func makeSubscriber(demand: Subscribers.Demand, expectation: XCTestExpectation?) -> AnySubscriber<String, MyError> {
+    return AnySubscriber(
+      receiveSubscription: { subscription in
+        XCTAssertEqual("\(subscription)", "Create.Subscription<String, MyError>")
+        subscription.request(demand)
+      },
+      receiveValue: { value in
+        self.values.append(value)
+        return .none
+      },
+      receiveCompletion: { finished in
+        self.completion = finished
+        expectation?.fulfill()
+      }
+    )
+  }
+}

--- a/Tests/ReactorKitCombineTests/IdentityEquatableTests.swift
+++ b/Tests/ReactorKitCombineTests/IdentityEquatableTests.swift
@@ -1,0 +1,29 @@
+//
+//  IdentityEquatableTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+import XCTest
+
+import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class IdentityEquatableTests: XCTestCase {
+  func testReactorEqual_whenCurrentStatesAreEqual() {
+    let reactorA = SimpleReactor()
+    let reactorB = reactorA
+    XCTAssertEqual(reactorA, reactorB)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private final class SimpleReactor: Reactor, IdentityEquatable {
+  typealias Action = Never
+  typealias Mutation = Never
+  struct State {
+  }
+
+  let initialState = State()
+}

--- a/Tests/ReactorKitCombineTests/IdentityHashableTests.swift
+++ b/Tests/ReactorKitCombineTests/IdentityHashableTests.swift
@@ -1,0 +1,30 @@
+//
+//  IdentityHashableTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+import XCTest
+
+import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class IdentityHashableTests: XCTestCase {
+  func testReactorHashValue() {
+    let reactorA = SimpleReactor()
+    let reactorB = reactorA
+    XCTAssertEqual(reactorA.hashValue, reactorB.hashValue)
+    XCTAssertEqual(reactorA, reactorB)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private final class SimpleReactor: Reactor, IdentityHashable {
+  typealias Action = Never
+  typealias Mutation = Never
+  struct State {
+  }
+
+  let initialState = State()
+}

--- a/Tests/ReactorKitCombineTests/ReactorSchedulerTests.swift
+++ b/Tests/ReactorKitCombineTests/ReactorSchedulerTests.swift
@@ -1,0 +1,127 @@
+//
+//  ReactorSchedulerTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+import XCTest
+
+import Combine
+import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension AnyPublisher: Equatable {
+  public static func == (lhs: AnyPublisher<Output, Failure>, rhs: AnyPublisher<Output, Failure>) -> Bool {
+    Swift.print(lhs, ObjectIdentifier(lhs as AnyObject).hashValue, rhs, ObjectIdentifier(rhs as AnyObject).hashValue)
+    return ObjectIdentifier(lhs as AnyObject).hashValue == ObjectIdentifier(rhs as AnyObject).hashValue
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class ReactorSchedulerTests: XCTestCase {
+  // TODO: How can I test same AnyPublisher
+  /*
+  func testStateStreamIsCreatedOnce() {
+    final class SimpleReactor: Reactor {
+      typealias Action = Never
+      typealias Mutation = Never
+      typealias State = Int
+
+      let initialState: State = 0
+
+      func transform(action: AnyPublisher<Action, Never>) -> AnyPublisher<Action, Never> {
+        sleep(5)
+        return action
+      }
+    }
+
+    let reactor = SimpleReactor()
+    var states: [AnyPublisher<SimpleReactor.State, Never>] = []
+    let lock = NSLock()
+
+    for _ in 0..<100 {
+      DispatchQueue.global().async {
+        let state = reactor.state
+        lock.lock()
+        states.append(state)
+        lock.unlock()
+      }
+    }
+
+    XCTWaiter().wait(for: [XCTestExpectation()], timeout: 10)
+
+    XCTAssertGreaterThan(states.count, 0)
+    for state in states {
+      XCTAssertTrue(state === states.first)
+    }
+  }
+  */
+
+  func testScheduler() {
+    final class SimpleReactor: Reactor {
+      typealias Action = Void
+      typealias Mutation = Void
+
+      struct State {
+        var reductionThreads: [Thread] = []
+      }
+
+      let initialState: State = State()
+      let scheduler = DispatchQueue.global()
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        let currentThread = Thread.current
+        newState.reductionThreads.append(currentThread)
+        return newState
+      }
+    }
+
+    let reactor = SimpleReactor()
+    var cancellables: Set<AnyCancellable> = []
+
+    var observationThreads: [Thread] = []
+
+    var isExecuted = false
+
+    DispatchQueue.global().async {
+      let currentThread = Thread.current
+
+      reactor.state
+        .sink(receiveValue: { _ in
+          let currentThread = Thread.current
+          observationThreads.append(currentThread)
+        })
+        .store(in: &cancellables)
+
+      for _ in 0..<100 {
+        reactor.action.send(Void())
+      }
+
+      XCTWaiter().wait(for: [XCTestExpectation()], timeout: 1)
+
+      let reductionThreads = reactor.currentState.reductionThreads
+      XCTAssertEqual(reductionThreads.count, 100)
+      for thread in reductionThreads {
+        XCTAssertNotEqual(thread, currentThread)
+      }
+
+      XCTAssertEqual(observationThreads.count, 101) // +1 for initial state
+
+      // initial state is observed on the same thread with the one where the state stream is created.
+      XCTAssertEqual(observationThreads[0], currentThread)
+
+      // other states are observed on the specified thread.
+      for thread in observationThreads[1...] {
+        XCTAssertNotEqual(thread, currentThread)
+      }
+
+      isExecuted = true
+    }
+
+    XCTWaiter().wait(for: [XCTestExpectation()], timeout: 1.5)
+    XCTAssertTrue(isExecuted)
+  }
+}
+

--- a/Tests/ReactorKitCombineTests/ReactorSchedulerTests.swift
+++ b/Tests/ReactorKitCombineTests/ReactorSchedulerTests.swift
@@ -20,8 +20,6 @@ extension AnyPublisher: Equatable {
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class ReactorSchedulerTests: XCTestCase {
-  // TODO: How can I test same AnyPublisher
-  /*
   func testStateStreamIsCreatedOnce() {
     final class SimpleReactor: Reactor {
       typealias Action = Never
@@ -51,12 +49,22 @@ final class ReactorSchedulerTests: XCTestCase {
 
     XCTWaiter().wait(for: [XCTestExpectation()], timeout: 10)
 
+    let firstStatePublisher: AnyObject? = {
+      guard let firstState = states.first else { return nil }
+      let mirror = Mirror(reflecting: firstState)
+      let box = mirror.children.first { $0.label == "box" }?.value
+      return box as AnyObject
+    }()
     XCTAssertGreaterThan(states.count, 0)
     for state in states {
-      XCTAssertTrue(state === states.first)
+      let statePublisher: AnyObject? = {
+        let mirror = Mirror(reflecting: state)
+        let box = mirror.children.first { $0.label == "box" }?.value
+        return box as AnyObject
+      }()
+      XCTAssertTrue(statePublisher === firstStatePublisher)
     }
   }
-  */
 
   func testScheduler() {
     final class SimpleReactor: Reactor {

--- a/Tests/ReactorKitCombineTests/ReactorTests.swift
+++ b/Tests/ReactorKitCombineTests/ReactorTests.swift
@@ -1,0 +1,389 @@
+//
+//  ReactorTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/06/30.
+//
+
+import XCTest
+
+import Combine
+@testable import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class ReactorTests: XCTestCase {
+  func testEachMethodsAreInvoked() {
+    // given
+    let reactor = TestReactor()
+    var cancellables: Set<AnyCancellable> = []
+    var receivedStates: [TestReactor.State] = []
+    reactor.state.sink(receiveValue: { receivedStates.append($0) }).store(in: &cancellables)
+
+    // when
+    reactor.action.send(["action"])
+
+    // then
+    XCTAssertEqual(receivedStates.count, 2)
+    XCTAssertEqual(receivedStates[0], ["transformedState"]) // initial state
+    XCTAssertEqual(receivedStates[1], ["action", "transformedAction", "mutation", "transformedMutation", "reduce", "transformedState"])
+  }
+
+  func testReduceIsExecutedRightAfterMutation() {
+    final class MyReactor: Reactor {
+      enum Action {
+        case append([String])
+      }
+
+      enum Mutation {
+        case setCharacters([String])
+      }
+
+      struct State {
+        var characters: [String] = []
+      }
+
+      let initialState = State()
+
+      func mutate(action: Action) -> AnyPublisher<Mutation, Never> {
+        switch action {
+        case let .append(characters):
+          let sources: [AnyPublisher<Mutation, Never>] = characters.map { character in
+            AnyPublisher<Mutation, Never>.create { [weak self] subscriber -> Cancellable in
+              if let self = self {
+                let newCharacters = self.currentState.characters + [character]
+                subscriber.send(Mutation.setCharacters(newCharacters))
+              }
+              subscriber.send(completion: .finished)
+              return AnyCancellable { }
+            }
+          }
+          return sources.publisher.flatMap { $0 }.eraseToAnyPublisher()
+        }
+      }
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .setCharacters(newCharacters):
+          newState.characters = newCharacters
+        }
+        return newState
+      }
+    }
+
+    let reactor = MyReactor()
+    reactor.action.send(.append(["a", "b"]))
+    reactor.action.send(.append(["c"]))
+    reactor.action.send(.append(["d", "e", "f"]))
+    XCTAssertEqual(reactor.currentState.characters, ["a", "b", "c", "d", "e", "f"])
+  }
+
+  func testStateReplayCurrentState() {
+    // given
+    let reactor = CounterReactor()
+
+    // when
+    let cancellable = reactor.state.sink(receiveValue: { _ in }) // state: 0
+    reactor.action.send(()) // state: 1
+    reactor.action.send(()) // state: 2
+    cancellable.cancel()
+
+    // then
+    var latestState: CounterReactor.State?
+    _ = reactor.state.sink(receiveValue: { latestState = $0 })
+    XCTAssertEqual(latestState, 2)
+  }
+
+  func testCurrentState() {
+    let reactor = TestReactor()
+    _ = reactor.state
+    reactor.action.send(["action"])
+    XCTAssertEqual(reactor.currentState, ["action", "transformedAction", "mutation", "transformedMutation", "reduce", "transformedState"])
+  }
+
+  func testCurrentState_stateIsCreatedWhenAccessAction() {
+    let reactor = TestReactor()
+    reactor.action.send(["action"])
+    XCTAssertEqual(reactor.currentState, ["action", "transformedAction", "mutation", "transformedMutation", "reduce", "transformedState"])
+  }
+
+  func testStreamIgnoresCompletedFromAction() {
+    // given
+    let reactor = CounterReactor()
+    let action1 = ActionSubject<CounterReactor.Action>()
+    let action2 = ActionSubject<CounterReactor.Action>()
+    var receivedStates: [CounterReactor.State] = []
+    var cancellables: Set<AnyCancellable> = []
+    action1.subscribe(reactor.action).store(in: &cancellables)
+    action2.subscribe(reactor.action).store(in: &cancellables)
+    reactor.state.sink(receiveValue: { receivedStates.append($0) }).store(in: &cancellables)
+
+    // when
+    action1.send(Void())
+    action1.send(Void())
+    action1.send(completion: .finished)
+    action2.send(completion: .finished)
+    action1.send(Void())
+    action2.send(Void())
+    action2.send(Void())
+
+    // then
+    XCTAssertEqual(receivedStates, [0, 1, 2, 3, 4, 5])
+  }
+
+  func testStreamIgnoresCompletedFromMutate() {
+    // given
+    let reactor = CounterReactor()
+    reactor.stateForTriggerCompleted = 2
+    var cancellables: Set<AnyCancellable> = []
+    var receivedStates: [CounterReactor.State] = []
+    reactor.state.sink(receiveValue: { receivedStates.append($0) }).store(in: &cancellables)
+
+    // when
+    reactor.action.send(Void())
+    reactor.action.send(Void())
+    reactor.action.send(Void()) // completed will be emit on this mutate
+    reactor.action.send(Void())
+    reactor.action.send(Void())
+
+    // then
+    XCTAssertEqual(receivedStates, [0, 1, 2, 3, 4, 5])
+  }
+
+  func testCancel() {
+    // given
+    let timerPublisher = PassthroughSubject<Date, Never>()
+    let reactor = StopwatchReactor(timePublisher: timerPublisher.eraseToAnyPublisher())
+    var cancellables: Set<AnyCancellable> = []
+    var receivedStates: [StopwatchReactor.State] = []
+    reactor.state.sink(receiveValue: { receivedStates.append($0) }).store(in: &cancellables)
+
+    // when
+    reactor.action.send(.start) // time: 1
+    timerPublisher.send(Date()) // time: 2
+    timerPublisher.send(Date()) // time: 3
+    timerPublisher.send(Date()) // time: 4
+    reactor.action.send(.stop)  // time: 5
+    reactor.action.send(.start) // time: 6
+    timerPublisher.send(Date()) // time: 7
+    timerPublisher.send(Date()) // time: 8
+    reactor.action.send(.stop)  // time: 9
+
+    // then
+    XCTAssertEqual(receivedStates, [
+      0, // time: 0
+         // time: 1 (start)
+      1, // time: 2
+      2, // time: 3
+      3, // time: 4
+         // time: 5 (stop)
+         // time: 6 (start)
+      4, // time: 7
+      5, // time: 8
+         // time: 9 (stop)
+    ])
+  }
+
+  func testStub_actionAndStateMemoryAddress() {
+    let reactor = TestReactor()
+    reactor.isStubEnabled = true
+    XCTAssertTrue(reactor.action === reactor.stub.action)
+    // TODO: How can I test same AnyPublisher
+    // XCTAssertTrue(reactor.state as AnyObject === reactor.stub.state)
+  }
+
+  func testStub_actions() {
+    let reactor = StopwatchReactor()
+    reactor.isStubEnabled = true
+    reactor.action.send(.start)
+    reactor.action.send(.start)
+    reactor.action.send(.stop)
+    XCTAssertEqual(reactor.stub.actions, [.start, .start, .stop])
+  }
+
+  func testStub_state() {
+    let reactor = StopwatchReactor()
+    reactor.isStubEnabled = true
+    reactor.stub.state.value = 0
+    XCTAssertEqual(reactor.currentState, 0)
+    reactor.stub.state.value = 1
+    XCTAssertEqual(reactor.currentState, 1)
+    reactor.stub.state.value = -10
+    XCTAssertEqual(reactor.currentState, -10)
+    reactor.stub.state.value = 30
+    XCTAssertEqual(reactor.currentState, 30)
+  }
+
+  func testStub_ignoreAction() {
+    let reactor = TestReactor()
+    reactor.isStubEnabled = true
+    reactor.action.send(["A"])
+    XCTAssertEqual(reactor.currentState, [])
+  }
+
+  /// A test for #30
+  func testGenericSubclassing() {
+    class ParentReactor<T>: Reactor {
+      enum Action {}
+      typealias Mutation = Void
+      typealias State = Void
+      let initialState: State = State()
+    }
+
+    class ChildReactor: ParentReactor<String> {
+    }
+
+    let reactor = ChildReactor()
+    let address1 = ObjectIdentifier(reactor.action).hashValue
+    _ = reactor.state
+    let address2 = ObjectIdentifier(reactor.action).hashValue
+    XCTAssertEqual(address1, address2)
+  }
+
+  func testGenericSubclassing_stateIsCreatedWhenAccessAction() {
+    class ParentReactor<T>: Reactor {
+      enum Action {
+        case foo
+      }
+      typealias Mutation = Void
+      typealias State = Int
+      let initialState: State = 0
+
+      func mutate(action: Action) -> AnyPublisher<Mutation, Never> {
+        return Just(Void()).eraseToAnyPublisher()
+      }
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        return state + 1
+      }
+    }
+
+    class ChildReactor: ParentReactor<String> {
+    }
+
+    let reactor = ChildReactor()
+    XCTAssertEqual(reactor.currentState, 0)
+    reactor.action.send(.foo)
+    XCTAssertEqual(reactor.currentState, 1)
+  }
+
+  func testDispose() {
+    // given
+    weak var weakReactor: TestReactor?
+    weak var weakAction: ActionSubject<TestReactor.Action>?
+    weak var weakState: AnyObject?// AnyPublisher<TestReactor.State, Never>?
+
+    // when
+    _ = {
+      let reactor = TestReactor()
+      weakReactor = reactor
+      weakAction = reactor.action
+      weakState = reactor.state as AnyObject
+    }()
+
+    // then
+    XCTAssertNil(weakReactor)
+    XCTAssertNil(weakAction)
+    XCTAssertNil(weakState)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private final class TestReactor: Reactor {
+  typealias Action = [String]
+  typealias Mutation = [String]
+  typealias State = [String]
+
+  let initialState = State()
+
+  // 1. ["action"] + ["transformedAction"]
+  func transform(action: AnyPublisher<Action, Never>) -> AnyPublisher<Action, Never> {
+    return action.map { action in action + ["transformedAction"] }.eraseToAnyPublisher()
+  }
+
+  // 2. ["action", "transformedAction"] + ["mutation"]
+  func mutate(action: Action) -> AnyPublisher<Mutation, Never> {
+    return Just(action + ["mutation"]).eraseToAnyPublisher()
+  }
+
+  // 3. ["action", "transformedAction", "mutation"] + ["transformedMutation"]
+  func transform(mutation: AnyPublisher<Mutation, Never>) -> AnyPublisher<Mutation, Never> {
+    return mutation.map { $0 + ["transformedMutation"] }.eraseToAnyPublisher()
+  }
+
+  // 4. [] + ["action", "transformedAction", "mutation", "transformedMutation"] + ["reduce"]
+  func reduce(state: State, mutation: Mutation) -> State {
+    return state + mutation + ["reduce"]
+  }
+
+  // 5. ["action", "transformedAction", "mutation", "transformedMutation", "reduce"] + ["transformedState"]
+  func transform(state: AnyPublisher<State, Never>) -> AnyPublisher<State, Never> {
+    return state.map { $0 + ["transformedState"] }.eraseToAnyPublisher()
+  }
+}
+
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private final class StopwatchReactor: Reactor {
+  enum Action {
+    case start
+    case stop
+  }
+  typealias Mutation = Int
+  typealias State = Int
+
+  fileprivate let timePublisher: AnyPublisher<Date, Never>
+  static let defaultTimePublisher = Timer.publish(every: 1, on: RunLoop.main, in: .default)
+    .autoconnect()
+    .eraseToAnyPublisher()
+  let initialState = 0
+
+  init(timePublisher: AnyPublisher<Date, Never> = StopwatchReactor.defaultTimePublisher) {
+    self.timePublisher = timePublisher
+  }
+
+  func mutate(action: Action) -> AnyPublisher<Mutation, Never> {
+    switch action {
+    case .start:
+      let stopAction = self.action.filter { $0 == .stop }
+      return self.timePublisher
+        .map { _ in 1 }
+        .prefix(untilOutputFrom: stopAction)
+        .eraseToAnyPublisher()
+
+    case .stop:
+      return Empty().eraseToAnyPublisher()
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> State {
+    return state + mutation
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private final class CounterReactor: Reactor {
+
+  typealias Action = Void
+  typealias Mutation = Void
+  typealias State = Int
+  let initialState = 0
+
+  var stateForTriggerCompleted: State?
+
+  func mutate(action: Void) -> AnyPublisher<Mutation, Never> {
+    if self.currentState == self.stateForTriggerCompleted {
+      let sources: [AnyPublisher<Mutation, Never>] = [
+        Just(action).eraseToAnyPublisher(),
+        Empty<Mutation, Never>().eraseToAnyPublisher(),
+      ]
+      return sources.publisher.flatMap { $0 }.eraseToAnyPublisher()
+    } else {
+      return Just(action).eraseToAnyPublisher()
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> State {
+    return state + 1
+  }
+}

--- a/Tests/ReactorKitCombineTests/ReactorTests.swift
+++ b/Tests/ReactorKitCombineTests/ReactorTests.swift
@@ -188,8 +188,14 @@ final class ReactorTests: XCTestCase {
     let reactor = TestReactor()
     reactor.isStubEnabled = true
     XCTAssertTrue(reactor.action === reactor.stub.action)
-    // TODO: How can I test same AnyPublisher
-    // XCTAssertTrue(reactor.state as AnyObject === reactor.stub.state)
+    let statePublisher: AnyObject? = {
+      let stateMirror = Mirror(reflecting: reactor.state)
+      guard let box = stateMirror.children.first(where: { $0.label == "box" })?.value else { return nil }
+      let boxMirror = Mirror(reflecting: box)
+      let base = boxMirror.children.first { $0.label == "base" }?.value
+      return base as AnyObject
+    }()
+    XCTAssertTrue(statePublisher === reactor.stub.state)
   }
 
   func testStub_actions() {

--- a/Tests/ReactorKitCombineTests/ReplaySubjectTests.swift
+++ b/Tests/ReactorKitCombineTests/ReplaySubjectTests.swift
@@ -1,0 +1,352 @@
+//
+//  ReplaySubjectTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/07/07.
+//
+//  implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt/blob/357e62bebcb2d64ac96dfe2233edb615f2714196/Tests/ReplaySubjectTests.swift).
+//
+
+import XCTest
+
+import Combine
+import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class ReplaySubjectTests: XCTestCase {
+  private var subscriptions = Set<AnyCancellable>()
+
+  private enum AnError: Error, Equatable {
+    case someError
+  }
+
+  func testReplaysNoValues() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 1)
+
+    var results = [Int]()
+
+    subject
+      .sink(receiveValue: { results.append($0) })
+      .store(in: &subscriptions)
+
+    XCTAssertTrue(results.isEmpty)
+  }
+
+  func testMissedValueWithEmptyBuffer() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 0)
+
+    subject.send(1)
+
+    var results = [Int]()
+
+    subject
+      .sink(receiveValue: { results.append($0) })
+      .store(in: &subscriptions)
+
+    subject.send(2)
+
+    XCTAssertEqual(results, [2])
+  }
+
+  func testMissedValueWithSingleBuffer() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 1)
+
+    subject.send(1)
+
+    var results = [Int]()
+
+    subject
+      .sink(receiveValue: { results.append($0) })
+      .store(in: &subscriptions)
+
+    subject.send(2)
+
+    XCTAssertEqual(results, [1, 2])
+  }
+
+  func testMissedValuesWithManyBuffer() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 3)
+
+    subject.send(1)
+    subject.send(2)
+    subject.send(3)
+    subject.send(4)
+
+    var results = [Int]()
+
+    subject
+      .sink(receiveValue: { results.append($0) })
+      .store(in: &subscriptions)
+
+    subject.send(5)
+
+    XCTAssertEqual(results, [2, 3, 4, 5])
+  }
+
+  func testMissedValuesWithManyBufferUnfilled() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 3)
+
+    subject.send(1)
+    subject.send(2)
+
+    var results = [Int]()
+
+    subject
+      .sink(receiveValue: { results.append($0) })
+      .store(in: &subscriptions)
+
+    subject.send(3)
+
+    XCTAssertEqual(results, [1, 2, 3])
+  }
+
+  func testMultipleSubscribers() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 3)
+
+    subject.send(1)
+    subject.send(2)
+
+    var results1 = [Int]()
+    var results2 = [Int]()
+    var results3 = [Int]()
+
+    subject
+      .sink(receiveValue: { results1.append($0) })
+      .store(in: &subscriptions)
+
+    subject
+      .sink(receiveValue: { results2.append($0) })
+      .store(in: &subscriptions)
+
+    subject
+      .sink(receiveValue: { results3.append($0) })
+      .store(in: &subscriptions)
+
+    subject.send(3)
+
+    XCTAssertEqual(results1, [1, 2, 3])
+    XCTAssertEqual(results2, [1, 2, 3])
+    XCTAssertEqual(results3, [1, 2, 3])
+  }
+
+  func testCompletionWithMultipleSubscribers() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 3)
+
+    subject.send(1)
+    subject.send(2)
+    subject.send(completion: .finished)
+
+    var results1 = [Int]()
+    var completions1 = [Subscribers.Completion<Never>]()
+
+    var results2 = [Int]()
+    var completions2 = [Subscribers.Completion<Never>]()
+
+    var results3 = [Int]()
+    var completions3 = [Subscribers.Completion<Never>]()
+
+    subject
+      .sink(
+        receiveCompletion: { completions1.append($0) },
+        receiveValue: { results1.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    subject
+      .sink(
+        receiveCompletion: { completions2.append($0) },
+        receiveValue: { results2.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    subject
+      .sink(
+        receiveCompletion: { completions3.append($0) },
+        receiveValue: { results3.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    subject.send(3)
+
+    XCTAssertEqual(results1, [1, 2])
+    XCTAssertEqual(completions1, [.finished])
+
+    XCTAssertEqual(results2, [1, 2])
+    XCTAssertEqual(completions2, [.finished])
+
+    XCTAssertEqual(results3, [1, 2])
+    XCTAssertEqual(completions3, [.finished])
+  }
+
+  func testErrorWithMultipleSubscribers() {
+    let subject = ReplaySubject<Int, AnError>(bufferSize: 3)
+
+    subject.send(1)
+    subject.send(2)
+    subject.send(completion: .failure(.someError))
+
+    var results1 = [Int]()
+    var completions1 = [Subscribers.Completion<AnError>]()
+
+    var results2 = [Int]()
+    var completions2 = [Subscribers.Completion<AnError>]()
+
+    var results3 = [Int]()
+    var completions3 = [Subscribers.Completion<AnError>]()
+
+
+    subject
+      .sink(
+        receiveCompletion: { completions1.append($0) },
+        receiveValue: { results1.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    subject
+      .sink(
+        receiveCompletion: { completions2.append($0) },
+        receiveValue: { results2.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    subject
+      .sink(
+        receiveCompletion: { completions3.append($0) },
+        receiveValue: { results3.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    subject.send(3)
+
+    XCTAssertEqual(results1, [1, 2])
+    XCTAssertEqual(completions1, [.failure(.someError)])
+
+    XCTAssertEqual(results2, [1, 2])
+    XCTAssertEqual(completions2, [.failure(.someError)])
+
+    XCTAssertEqual(results3, [1, 2])
+    XCTAssertEqual(completions3, [.failure(.someError)])
+  }
+
+  func testValueAndCompletionPreSubscribe() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 1)
+
+    subject.send(1)
+    subject.send(completion: .finished)
+
+    var results1 = [Int]()
+    var completed = false
+
+    subject
+      .sink(
+        receiveCompletion: { _ in completed = true },
+        receiveValue: { results1.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    XCTAssertEqual(results1, [1])
+    XCTAssertTrue(completed)
+  }
+
+  func testNoValuesReplayedPostCompletion() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 1)
+
+    subject.send(1)
+    subject.send(completion: .finished)
+    subject.send(2)
+
+    var results1 = [Int]()
+    var completed = false
+
+    subject
+      .sink(
+        receiveCompletion: { _ in completed = true },
+        receiveValue: { results1.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    XCTAssertEqual(results1, [1])
+    XCTAssertTrue(completed)
+  }
+
+  func testNoValuesReplayedPostError() {
+    let subject = ReplaySubject<Int, AnError>(bufferSize: 1)
+
+    subject.send(1)
+    subject.send(completion: .failure(.someError))
+    subject.send(2)
+
+    var results1 = [Int]()
+    var completed = false
+
+    subject
+      .sink(
+        receiveCompletion: { _ in completed = true },
+        receiveValue: { results1.append($0) }
+    )
+      .store(in: &subscriptions)
+
+    XCTAssertEqual(results1, [1])
+    XCTAssertTrue(completed)
+  }
+
+  private var demandSubscription: Subscription!
+  func testRespectsDemand() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 4)
+
+    subject.send(1)
+    subject.send(2)
+    subject.send(3)
+    subject.send(4)
+
+    var results = [Int]()
+    var completed = false
+
+    let subscriber = AnySubscriber<Int, Never>(
+      receiveSubscription: { subscription in
+        self.demandSubscription = subscription
+        subscription.request(.max(3))
+    },
+      receiveValue: { results.append($0); return .none },
+      receiveCompletion: { _ in completed = true }
+    )
+
+    subject
+      .subscribe(subscriber)
+
+    XCTAssertEqual(results, [1, 2, 3])
+    XCTAssertFalse(completed)
+
+    subject.send(completion: .finished)
+
+    XCTAssertTrue(completed)
+  }
+
+  func testDoubleSubscribe() {
+    let subject = ReplaySubject<Int, Never>(bufferSize: 1)
+
+    subject.send(1)
+    subject.send(2)
+    subject.send(completion: .finished)
+
+    var results = [String]()
+    var completions = [Subscribers.Completion<Never>]()
+
+    let subscriber = AnySubscriber<String, Never>(
+      receiveSubscription: { $0.request(.max(1)) },
+      receiveValue: { results.append($0); return .none },
+      receiveCompletion: { completions.append($0) }
+    )
+
+    subject
+      .map { "a\($0)" }
+      .subscribe(subscriber)
+
+    subject
+      .map { "b\($0)" }
+      .subscribe(subscriber)
+
+    XCTAssertEqual(["a2", "b2"], results)
+    XCTAssertEqual([.finished, .finished], completions)
+  }
+}

--- a/Tests/ReactorKitCombineTests/ReplaySubjectTests.swift
+++ b/Tests/ReactorKitCombineTests/ReplaySubjectTests.swift
@@ -10,7 +10,7 @@
 import XCTest
 
 import Combine
-import ReactorKitCombine
+@testable import ReactorKitCombine
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class ReplaySubjectTests: XCTestCase {

--- a/Tests/ReactorKitCombineTests/StateRelayTests.swift
+++ b/Tests/ReactorKitCombineTests/StateRelayTests.swift
@@ -1,0 +1,127 @@
+//
+//  StateRelayTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+import XCTest
+
+import Combine
+@testable import ReactorKitCombine
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class StateRelayTests: XCTestCase {
+  func testInitialValue() {
+    let relay = StateRelay("initial")
+    XCTAssertEqual(relay.value, "initial")
+  }
+
+  func testValueGetter() {
+    // given
+    let relay = StateRelay("")
+
+    // when & then
+    relay.accept("second")
+    XCTAssertEqual(relay.value, "second")
+
+    relay.accept("third")
+    XCTAssertEqual(relay.value, "third")
+  }
+
+  func testValueSetter() {
+    // given
+    let relay = StateRelay("")
+
+    // when & then
+    relay.value = "second"
+    XCTAssertEqual(relay.value, "second")
+
+    relay.value = "third"
+    XCTAssertEqual(relay.value, "third")
+  }
+
+  func testAccept() {
+    // given
+    let relay = StateRelay(0)
+
+    // when & then
+    relay.accept(100)
+    XCTAssertEqual(relay.value, 100)
+
+    relay.accept(200)
+    XCTAssertEqual(relay.value, 200)
+
+    relay.accept(300)
+    XCTAssertEqual(relay.value, 300)
+  }
+
+  func testFinishesOnDeinit() {
+    // given
+    var relay: StateRelay<Void>? = StateRelay(Void())
+    var cancellables: Set<AnyCancellable> = []
+
+    var isCompleted = false
+    relay?
+      .sink(
+        receiveCompletion: { _ in isCompleted = true },
+        receiveValue: { _ in }
+      )
+      .store(in: &cancellables)
+
+    XCTAssertFalse(isCompleted)
+
+    // when
+    relay = nil
+
+    // then
+    XCTAssertTrue(isCompleted)
+  }
+
+  func testReplaysCurrentValue() {
+    // given
+    let relay = StateRelay("initial")
+    var cancellables: Set<AnyCancellable> = []
+
+    var receivedValues: [String] = []
+    relay
+      .sink(receiveValue: { receivedValues.append($0) })
+      .store(in: &cancellables)
+    XCTAssertEqual(receivedValues, ["initial"])
+
+    relay.accept("yo")
+    XCTAssertEqual(receivedValues, ["initial", "yo"])
+
+    // when
+    var secondReceivedValues: [String] = []
+    relay.sink(receiveValue: { secondReceivedValues.append($0) }).store(in: &cancellables)
+
+    // then
+    XCTAssertEqual(secondReceivedValues, ["yo"])
+  }
+
+  func testSubscribePublisher() {
+    // given
+    let relay = StateRelay("initial")
+    var cancellables: Set<AnyCancellable> = []
+
+    var isCompleted = false
+    var receivedValues: [String] = []
+    relay
+      .sink(
+        receiveCompletion: { _ in isCompleted = true },
+        receiveValue: { receivedValues.append($0) }
+      )
+      .store(in: &cancellables)
+
+    // when
+    ["1", "2", "3"]
+      .publisher
+      .subscribe(relay)
+      .store(in: &cancellables)
+
+    // then
+    XCTAssertFalse(isCompleted)
+    XCTAssertEqual(receivedValues, ["initial", "1", "2", "3"])
+  }
+}

--- a/Tests/ReactorKitCombineTests/ViewTests.swift
+++ b/Tests/ReactorKitCombineTests/ViewTests.swift
@@ -1,0 +1,103 @@
+
+//
+//  StateRelayTests.swift
+//  ReactorKitCombineTests
+//
+//  Created by tokijh on 2020/07/06.
+//
+
+import XCTest
+
+import Combine
+import ReactorKitCombine
+
+#if os(iOS) || os(tvOS)
+import UIKit
+private typealias OSViewController = UIViewController
+private typealias OSView = UIView
+#elseif os(OSX)
+import AppKit
+private typealias OSViewController = NSViewController
+private typealias OSView = NSView
+#endif
+
+#if !os(Linux)
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class ViewTests: XCTestCase {
+  func testBindIsInvoked_differentReactor() {
+    // given
+    let view = TestView()
+
+    // when & then
+    XCTAssertEqual(view.bindInvokeCount, 0)
+
+    view.reactor = TestReactor()
+    XCTAssertEqual(view.bindInvokeCount, 1)
+
+    view.reactor = TestReactor()
+    XCTAssertEqual(view.bindInvokeCount, 2)
+  }
+
+  func testClearCancellablesWhenSetDifferentReactor() {
+    // given
+    let view = TestView()
+
+    // when & then
+    XCTAssertTrue(view.cancellables.isEmpty)
+
+    let oldHashValue = view.cancellables
+    view.reactor = TestReactor()
+    XCTAssertFalse(view.cancellables.isEmpty)
+
+    let newHashValue = view.cancellables
+    view.reactor = TestReactor()
+    XCTAssertFalse(view.cancellables.isEmpty)
+
+    XCTAssertNotEqual(oldHashValue, newHashValue)
+  }
+
+  func testReactor_assign() {
+    // given
+    let reactor = TestReactor()
+    let view = TestView()
+
+    // when
+    view.reactor = reactor
+
+    // then
+    XCTAssertNotNil(view.reactor)
+    XCTAssertTrue(view.reactor === reactor)
+  }
+
+  func testReactor_assignNil() {
+    // given
+    let reactor = TestReactor()
+    let view = TestView()
+    view.reactor = reactor
+
+    // when
+    view.reactor = nil
+
+    // then
+    XCTAssertNil(view.reactor)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private final class TestView: View {
+  var cancellables: Set<AnyCancellable> = []
+  var bindInvokeCount = 0
+
+  func bind(reactor: TestReactor) {
+    self.bindInvokeCount += 1
+    reactor.state.sink(receiveValue: { _ in }).store(in: &self.cancellables)
+  }
+}
+
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private final class TestReactor: Reactor {
+  typealias Action = Never
+  struct State {}
+  let initialState = State()
+}
+#endif


### PR DESCRIPTION
# ReactorKit for Combine 🚀

**This PR does not consider SwiftUI.**
**I just wrote Core as Combine.**

## Works

- Add `ReactorKitCombine` target to Package.swift
- ActionSubject for Combine
- Replay for Combine
  - `ReplaySubject` and `DemandBuffer`
    - implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt).
- StateRelay for Combine
  - Add `Relay`, `Sink` and `DemandBuffer`.
    - implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt).
- Reactor for Combine
- View for Combine
- `Publisher.create()` for ReactorKitCombineTests
    - implementation borrows heavily from [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt).

## Review Notes

- `StoryboardView` does not support!
  - I don't like method swizzling. I want to support it when there is another solution.
  - If there is a user who wants more, I will add it.
  - But, if you want to support it right now, Please PR to ReactorKit or this PR.
- Support Specify a scheduler #128
  - But there is much debate about this feature.
  - This PR is made based on the master branch and is thought to have an impact on these issues, #149 #152, but it will be reflected as soon as the discussion is completed.
- I'm sorry I couldn't keep the commit small...

## Questions

- [x] How can I test the same AnyPublisher?
  - There are some tests to verify that the `Reactor.state` is the same instance
There is a code to verify that the state is the same instance.
  And to verify this, it must be possible to verify whether Publisher is the same instance or not.
  - <details><summary>I tried <code>ObjectIdentifier()</code>, but it always passes the test, unlike expected fail</summary>

    ```swift
    func testStateStreamIsCreatedOnce() {
      final class SimpleReactor: Reactor {
        typealias Action = Never
        typealias Mutation = Never
        typealias State = Int

        let initialState: State = 0

        func transform(action: AnyPublisher<Action, Never>) -> AnyPublisher<Action, Never> {
          sleep(5)
          return action
        }
      }

      let reactor = SimpleReactor()
      var states: [AnyPublisher<SimpleReactor.State, Never>] = []
      let lock = NSLock()

      for _ in 0..<100 {
        DispatchQueue.global().async {
          let state = reactor.state
          lock.lock()
          states.append(state)
          lock.unlock()
        }
      }

      XCTWaiter().wait(for: [XCTestExpectation()], timeout: 10)

      states.append(Empty().eraseToAnyPublisher()) // This test must be failed by this code

      XCTAssertGreaterThan(states.count, 0)
      for state in states {
        XCTAssertTrue(ObjectIdentifier(state as AnyObject) == ObjectIdentifier(states.first as AnyObject))
      }
    }
    ```    
    </details>
  - See `testStateStreamIsCreatedOnce()` and `testStub_actionAndStateMemoryAddress()`.
  - Solved! See 5607cf959eb4f692b7478a0045834fa31966cb54 (Thanks @devxoul !)

## TODOs

- [ ] Update README
- [ ] Create a example

## Special Thanks to...

- [CombineCommunity/CombineExt](https://github.com/CombineCommunity/CombineExt)
- @OhKangHoon
- @devxoul 