### PR TITLE
Make Reactor Equatable and Hashable if State is Equatable or Hashable

### DIFF
--- a/Sources/ReactorKit/Reactor+Equatable.swift
+++ b/Sources/ReactorKit/Reactor+Equatable.swift
@@ -1,0 +1,12 @@
+//
+//  Reacctor+Equatable.swift
+//  ReactorKit
+//
+//  Created by Suyeol Jeon on 2019/10/17.
+//
+
+public extension Reactor where Self: Equatable, State: Equatable {
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.currentState == rhs.currentState
+  }
+}

--- a/Sources/ReactorKit/Reactor+Hashable.swift
+++ b/Sources/ReactorKit/Reactor+Hashable.swift
@@ -1,0 +1,12 @@
+//
+//  Reactor+Hashable.swift
+//  ReactorKit
+//
+//  Created by Suyeol Jeon on 2019/10/17.
+//
+
+public extension Reactor where Self: Hashable, State: Hashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.currentState.hashValue)
+  }
+}

--- a/Tests/ReactorKitTests/ReactorEquatableTests.swift
+++ b/Tests/ReactorKitTests/ReactorEquatableTests.swift
@@ -1,0 +1,69 @@
+//
+//  ReactorEquatableTests.swift
+//  ReactorKitTests
+//
+//  Created by Suyeol Jeon on 2019/10/17.
+//
+
+import XCTest
+import ReactorKit
+import RxSwift
+
+final class ReactorEquatableTests: XCTestCase {
+  func testReactorEqual_whenCurrentStatesAreEqual() {
+    let reactorA = PostReactor(id: "a", viewCount: 0)
+    let reactorB = PostReactor(id: "a", viewCount: 1)
+    XCTAssertNotEqual(reactorA.currentState, reactorB.currentState)
+    XCTAssertNotEqual(reactorA, reactorB)
+
+    reactorA.action.onNext(.view)
+    XCTAssertEqual(reactorA.currentState, reactorB.currentState)
+    XCTAssertEqual(reactorA, reactorB)
+
+    reactorA.action.onNext(.view)
+    XCTAssertNotEqual(reactorA.currentState, reactorB.currentState)
+    XCTAssertNotEqual(reactorA, reactorB)
+
+
+    reactorB.action.onNext(.view)
+    XCTAssertEqual(reactorA.currentState, reactorB.currentState)
+    XCTAssertEqual(reactorA, reactorB)
+  }
+}
+
+private final class PostReactor: Reactor, Equatable {
+  enum Action {
+    case view
+  }
+
+  enum Mutation {
+    case increaseViewCount
+  }
+
+  struct State: Equatable {
+    var id: String
+    var viewCount: Int
+  }
+
+  let initialState: State
+
+  init(id: String, viewCount: Int) {
+    self.initialState = State(id: id, viewCount: viewCount)
+  }
+
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .view:
+      return .just(.increaseViewCount)
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> PostReactor.State {
+    var newState = state
+    switch mutation {
+    case .increaseViewCount:
+      newState.viewCount += 1
+    }
+    return newState
+  }
+}

--- a/Tests/ReactorKitTests/ReactorHashableTests.swift
+++ b/Tests/ReactorKitTests/ReactorHashableTests.swift
@@ -1,0 +1,69 @@
+//
+//  ReactorHashableTests.swift
+//  ReactorKitTests
+//
+//  Created by Suyeol Jeon on 2019/10/17.
+//
+
+import XCTest
+import ReactorKit
+import RxSwift
+
+final class ReactorHashableTests: XCTestCase {
+  func testReactorHashValue() {
+    let reactorA = PostReactor(id: "a", viewCount: 0)
+    let reactorB = PostReactor(id: "a", viewCount: 1)
+    XCTAssertNotEqual(reactorA.currentState.hashValue, reactorB.currentState.hashValue)
+    XCTAssertNotEqual(reactorA.hashValue, reactorB.hashValue)
+
+    reactorA.action.onNext(.view)
+    XCTAssertEqual(reactorA.currentState.hashValue, reactorB.currentState.hashValue)
+    XCTAssertEqual(reactorA.hashValue, reactorB.hashValue)
+
+    reactorA.action.onNext(.view)
+    XCTAssertNotEqual(reactorA.currentState.hashValue, reactorB.currentState.hashValue)
+    XCTAssertNotEqual(reactorA.hashValue, reactorB.hashValue)
+
+
+    reactorB.action.onNext(.view)
+    XCTAssertEqual(reactorA.currentState.hashValue, reactorB.currentState.hashValue)
+    XCTAssertEqual(reactorA.hashValue, reactorB.hashValue)
+  }
+}
+
+private final class PostReactor: Reactor, Hashable {
+  enum Action {
+    case view
+  }
+
+  enum Mutation {
+    case increaseViewCount
+  }
+
+  struct State: Hashable {
+    var id: String
+    var viewCount: Int
+  }
+
+  let initialState: State
+
+  init(id: String, viewCount: Int) {
+    self.initialState = State(id: id, viewCount: viewCount)
+  }
+
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .view:
+      return .just(.increaseViewCount)
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> PostReactor.State {
+    var newState = state
+    switch mutation {
+    case .increaseViewCount:
+      newState.viewCount += 1
+    }
+    return newState
+  }
+}


### PR DESCRIPTION
## Background

If a Reactor has other Reactors as a State, it is difficult to use `distinctUntilChanged()` on it. It's important to use `distinctUntilChanged()` to prevent from unnecessary view re-rendering. This PR introduces a new functionality that automatically makes Reactor as an Equatable/Hashable if its State is also an Equatable/Hashable.

**Before**

```swift
class ItemListReactor {
  struct State {
    var itemReactors: [ItemReactor]
  }
}
```

```swift
reactor.state.map { $0 }
  .distinctUntilChanged() // 🚫 [ItemReactor] is not Equatable
  .subscribe(...)
```

**After**

<pre>
class ItemListReactor<strong>: Equatable</strong> {
  struct State<strong>: Equatable</strong> {
    var itemReactors: [ItemReactor]
  }
}
</pre>

```swift
reactor.state.map { $0 }
  .distinctUntilChanged() // ✅
  .subscribe(...)
```