### PR TITLE
Ensure that mutate and reduce are executed in the same serial scheduler

### DIFF
--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -128,7 +128,7 @@ extension Reactor {
   }
 
   public func createStateStream() -> Observable<State> {
-    let action = self._action.asObservable()
+    let action = self._action.observeOn(self.scheduler)
     let transformedAction = self.transform(action: action)
     let mutation = transformedAction
       .flatMap { [weak self] action -> Observable<Mutation> in
@@ -136,8 +136,7 @@ extension Reactor {
         return self.mutate(action: action).catchError { _ in .empty() }
       }
     let transformedMutation = self.transform(mutation: mutation)
-    let state = transformedMutation
-      .observeOn(self.scheduler)
+    let state = transformedMutation         
       .scan(self.initialState) { [weak self] state, mutation -> State in
         guard let `self` = self else { return state }
         return self.reduce(state: state, mutation: mutation)

--- a/Tests/ReactorKitTests/ReactorSchedulerTests.swift
+++ b/Tests/ReactorKitTests/ReactorSchedulerTests.swift
@@ -57,10 +57,6 @@ final class ReactorSchedulerTests: XCTestCase {
       let initialState: State = State()
       let scheduler: ImmediateSchedulerType = SerialDispatchQueueScheduler(qos: .default)
 
-      func mutate(action: Action) -> Observable<Mutation> {
-        return Observable.just(Void()).observeOn(MainScheduler.instance)
-      }
-
       func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         let currentThread = Thread.current


### PR DESCRIPTION
If the `mutate()` and `reduce()` are performed in the difference scheduler, it will break the proper order of executions.