### PR TITLE
Ensure that the last published state can be observed immediately.

### DIFF
--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -149,7 +149,7 @@ extension Reactor {
       })
       .replay(1)
     transformedState.connect().disposed(by: self.disposeBag)
-    return transformedState.observeOn(self.scheduler)
+    return transformedState
   }
 
   public func transform(action: Observable<Action>) -> Observable<Action> {


### PR DESCRIPTION
## Background

In the existing `Reactor` implementation code, The operation publishing the first state is executed by the scheduler assigned to the `Reactor`.

As a result, the first time you subscribed to the state stream, the first state isn't observed immediately at the same time you subscribed. This issue can lead to the problem that the required data isn't filled when the UI is first drawn.

## Changes

This PR ensures that the last state, published to the state stream, can be observed as soon as you subscribe to the stream. In addition, it ensures consistency of when the last state was observed.
   - The logic that handles the observed state can be executed immediately upon subscription.
   - Executing the logic immediately means that the thread, calling the stream subscription, executes the logic immediately after calling the subscription.
