### PR TITLE
mutating reactor state within reducer method using inout keyword

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/Counter/Counter.xcodeproj/project.pbxproj
+++ b/Examples/Counter/Counter.xcodeproj/project.pbxproj
@@ -37,8 +37,8 @@
 		035053411F61C325008E8863 /* CounterViewReactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CounterViewReactor.swift; sourceTree = "<group>"; };
 		03F235ED244C2E8D003B7446 /* GitHubSearch.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GitHubSearch.xcodeproj; path = ../GitHubSearch/GitHubSearch.xcodeproj; sourceTree = "<group>"; };
 		51B4C3728455C73235AA1B33 /* Pods_Example_Counter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_Counter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7C070D54E231EB5BFAC0BA70 /* Pods-Example-Counter.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Counter.debug.xcconfig"; path = "Target Support Files/Pods-Example-Counter/Pods-Example-Counter.debug.xcconfig"; sourceTree = "<group>"; };
-		DC5AF3EF6AAA10E38857BD02 /* Pods-Example-Counter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Counter.release.xcconfig"; path = "Target Support Files/Pods-Example-Counter/Pods-Example-Counter.release.xcconfig"; sourceTree = "<group>"; };
+		862177901A8E18E3436A8519 /* Pods-Example-Counter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Counter.release.xcconfig"; path = "Target Support Files/Pods-Example-Counter/Pods-Example-Counter.release.xcconfig"; sourceTree = "<group>"; };
+		AC6FFD7BEFDEC41864DEBC85 /* Pods-Example-Counter.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Counter.debug.xcconfig"; path = "Target Support Files/Pods-Example-Counter/Pods-Example-Counter.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,8 +105,8 @@
 		7082DFF53EF14F498683E0CC /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				7C070D54E231EB5BFAC0BA70 /* Pods-Example-Counter.debug.xcconfig */,
-				DC5AF3EF6AAA10E38857BD02 /* Pods-Example-Counter.release.xcconfig */,
+				AC6FFD7BEFDEC41864DEBC85 /* Pods-Example-Counter.debug.xcconfig */,
+				862177901A8E18E3436A8519 /* Pods-Example-Counter.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -146,6 +146,7 @@
 				TargetAttributes = {
 					034F94BF1EB789F400CB9EF1 = {
 						CreatedOnToolsVersion = 8.3.2;
+						DevelopmentTeam = CG9RTC2HJD;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
@@ -397,9 +398,10 @@
 		};
 		034F94D31EB789F400CB9EF1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7C070D54E231EB5BFAC0BA70 /* Pods-Example-Counter.debug.xcconfig */;
+			baseConfigurationReference = AC6FFD7BEFDEC41864DEBC85 /* Pods-Example-Counter.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CG9RTC2HJD;
 				INFOPLIST_FILE = Counter/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Counter;
@@ -410,9 +412,10 @@
 		};
 		034F94D41EB789F400CB9EF1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC5AF3EF6AAA10E38857BD02 /* Pods-Example-Counter.release.xcconfig */;
+			baseConfigurationReference = 862177901A8E18E3436A8519 /* Pods-Example-Counter.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CG9RTC2HJD;
 				INFOPLIST_FILE = Counter/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Counter;

--- a/Examples/Counter/Counter/CounterViewReactor.swift
+++ b/Examples/Counter/Counter/CounterViewReactor.swift
@@ -58,8 +58,7 @@ final class CounterViewReactor: Reactor {
   }
 
   // Mutation -> State
-  func reduce(state: State, mutation: Mutation) -> State {
-    var state = state
+  func reduce(state: inout State, mutation: Mutation) {
     switch mutation {
     case .increaseValue:
       state.value += 1
@@ -70,6 +69,5 @@ final class CounterViewReactor: Reactor {
     case let .setLoading(isLoading):
       state.isLoading = isLoading
     }
-    return state
   }
 }

--- a/Examples/GitHubSearch/GitHubSearch.xcodeproj/project.pbxproj
+++ b/Examples/GitHubSearch/GitHubSearch.xcodeproj/project.pbxproj
@@ -25,9 +25,9 @@
 		030AD4691EC5BC3300360E05 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		030AD46B1EC5BC3300360E05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		031F76491EC63D1500E9BAEA /* GitHubSearchViewReactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSearchViewReactor.swift; sourceTree = "<group>"; };
-		210850100AF5C900E1771E50 /* Pods-Example-GitHubSearch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-GitHubSearch.debug.xcconfig"; path = "Target Support Files/Pods-Example-GitHubSearch/Pods-Example-GitHubSearch.debug.xcconfig"; sourceTree = "<group>"; };
+		39584C2065206D613A59363A /* Pods-Example-GitHubSearch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-GitHubSearch.release.xcconfig"; path = "Target Support Files/Pods-Example-GitHubSearch/Pods-Example-GitHubSearch.release.xcconfig"; sourceTree = "<group>"; };
+		434A4BBADB60073A605F4902 /* Pods-Example-GitHubSearch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-GitHubSearch.debug.xcconfig"; path = "Target Support Files/Pods-Example-GitHubSearch/Pods-Example-GitHubSearch.debug.xcconfig"; sourceTree = "<group>"; };
 		D79957DB17989B06CE67AC7E /* Pods_Example_GitHubSearch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_GitHubSearch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F5BE0349B44453D1BF483BE6 /* Pods-Example-GitHubSearch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-GitHubSearch.release.xcconfig"; path = "Target Support Files/Pods-Example-GitHubSearch/Pods-Example-GitHubSearch.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,8 +77,8 @@
 		3BC93782B996756E59284E8E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				210850100AF5C900E1771E50 /* Pods-Example-GitHubSearch.debug.xcconfig */,
-				F5BE0349B44453D1BF483BE6 /* Pods-Example-GitHubSearch.release.xcconfig */,
+				434A4BBADB60073A605F4902 /* Pods-Example-GitHubSearch.debug.xcconfig */,
+				39584C2065206D613A59363A /* Pods-Example-GitHubSearch.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -126,6 +126,7 @@
 				TargetAttributes = {
 					030AD45B1EC5BC3300360E05 = {
 						CreatedOnToolsVersion = 8.3.2;
+						DevelopmentTeam = CG9RTC2HJD;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
@@ -361,9 +362,10 @@
 		};
 		030AD46F1EC5BC3300360E05 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 210850100AF5C900E1771E50 /* Pods-Example-GitHubSearch.debug.xcconfig */;
+			baseConfigurationReference = 434A4BBADB60073A605F4902 /* Pods-Example-GitHubSearch.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CG9RTC2HJD;
 				INFOPLIST_FILE = GitHubSearch/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.GitHubSearch;
@@ -374,9 +376,10 @@
 		};
 		030AD4701EC5BC3300360E05 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F5BE0349B44453D1BF483BE6 /* Pods-Example-GitHubSearch.release.xcconfig */;
+			baseConfigurationReference = 39584C2065206D613A59363A /* Pods-Example-GitHubSearch.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CG9RTC2HJD;
 				INFOPLIST_FILE = GitHubSearch/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.GitHubSearch;

--- a/Examples/GitHubSearch/GitHubSearch/GitHubSearchViewReactor.swift
+++ b/Examples/GitHubSearch/GitHubSearch/GitHubSearchViewReactor.swift
@@ -64,29 +64,21 @@ final class GitHubSearchViewReactor: Reactor {
     }
   }
 
-  func reduce(state: State, mutation: Mutation) -> State {
+  func reduce(state: inout State, mutation: Mutation) {
     switch mutation {
     case let .setQuery(query):
-      var newState = state
-      newState.query = query
-      return newState
+      state.query = query
 
     case let .setRepos(repos, nextPage):
-      var newState = state
-      newState.repos = repos
-      newState.nextPage = nextPage
-      return newState
+      state.repos = repos
+      state.nextPage = nextPage
 
     case let .appendRepos(repos, nextPage):
-      var newState = state
-      newState.repos.append(contentsOf: repos)
-      newState.nextPage = nextPage
-      return newState
+      state.repos.append(contentsOf: repos)
+      state.nextPage = nextPage
 
     case let .setLoadingNextPage(isLoadingNextPage):
-      var newState = state
-      newState.isLoadingNextPage = isLoadingNextPage
-      return newState
+      state.isLoadingNextPage = isLoadingNextPage
     }
   }
 

--- a/Examples/Podfile.lock
+++ b/Examples/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ReactorKit (2.0.1):
+  - ReactorKit (2.1.0):
     - RxSwift (~> 5.0)
     - WeakMapTable (~> 1.1)
   - RxCocoa (5.1.1):
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ReactorKit: c0c1f3cb6e7909086a40b8f39bd9201cefb05701
+  ReactorKit: 12a93358c554bb3f167b16b14c40374fa9cd5acd
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
   RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
   RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
@@ -35,4 +35,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 46a2c885520796f08b2992d490a2e294f6fbefc7
 
-COCOAPODS: 1.9.0
+COCOAPODS: 1.8.4

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -58,7 +58,7 @@ public protocol Reactor: class {
   /// observables. This method is called once before the state stream is created.
   func transform(mutation: Observable<Mutation>) -> Observable<Mutation>
 
-  /// Generates a new state with the previous state and the action. It should be purely functional
+  /// Mutates the state. It should be purely functional
   /// so it should not perform any side-effects here. This method is called every time when the
   /// mutation is committed.
   func reduce(state: inout State, mutation: Mutation)

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -139,8 +139,10 @@ extension Reactor {
     let transformedMutation = self.transform(mutation: mutation)
     let state = transformedMutation         
       .scan(self.initialState) { [weak self] state, mutation -> State in
+        var newState = state
         guard let `self` = self else { return state }
-        return self.reduce(state: state, mutation: mutation)
+        self.reduce(state: &newState, mutation: mutation)
+        return newState
       }
       .catchError { _ in .empty() }
       .startWith(self.initialState)

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -61,7 +61,7 @@ public protocol Reactor: class {
   /// Generates a new state with the previous state and the action. It should be purely functional
   /// so it should not perform any side-effects here. This method is called every time when the
   /// mutation is committed.
-  func reduce(state: State, mutation: Mutation) -> State
+  func reduce(state: inout State, mutation: Mutation)
 
   /// Transforms the state stream. Use this function to perform side-effects such as logging. This
   /// method is called once after the state stream is created.
@@ -165,8 +165,7 @@ extension Reactor {
     return mutation
   }
 
-  public func reduce(state: State, mutation: Mutation) -> State {
-    return state
+  public func reduce(state: inout State, mutation: Mutation) {
   }
 
   public func transform(state: Observable<State>) -> Observable<State> {

--- a/Tests/ReactorKitTests/ReactorTests.swift
+++ b/Tests/ReactorKitTests/ReactorTests.swift
@@ -51,13 +51,11 @@ final class ReactorTests: XCTestCase {
         }
       }
 
-      func reduce(state: State, mutation: Mutation) -> State {
-        var newState = state
+      func reduce(state: inout State, mutation: Mutation) {
         switch mutation {
         case let .setCharacters(newCharacters):
-          newState.characters = newCharacters
+          state.characters = newCharacters
         }
-        return newState
       }
     }
 
@@ -274,8 +272,8 @@ final class ReactorTests: XCTestCase {
         return .just(Void())
       }
 
-      func reduce(state: State, mutation: Mutation) -> State {
-        return state + 1
+      func reduce(state: inout State, mutation: Mutation) {
+        state = state + 1
       }
     }
 
@@ -332,8 +330,8 @@ private final class TestReactor: Reactor {
   }
 
   // 4. [] + ["action", "transformedAction", "mutation", "transformedMutation"] + ["reduce"]
-  func reduce(state: State, mutation: Mutation) -> State {
-    return state + mutation + ["reduce"]
+  func reduce(state: inout State, mutation: Mutation) {
+    state = state + mutation + ["reduce"]
   }
 
   // 5. ["action", "transformedAction", "mutation", "transformedMutation", "reduce"] + ["transformedState"]
@@ -371,8 +369,8 @@ private final class StopwatchReactor: Reactor {
     }
   }
 
-  func reduce(state: State, mutation: Mutation) -> State {
-    return state + mutation
+  func reduce(state: inout State, mutation: Mutation) {
+    state = state + mutation
   }
 }
 
@@ -395,7 +393,7 @@ private final class CounterReactor: Reactor {
     }
   }
 
-  func reduce(state: State, mutation: Mutation) -> State {
-    return state + 1
+  func reduce(state: inout State, mutation: Mutation) {
+    state = state + 1
   }
 }


### PR DESCRIPTION
By mutating the state within the reducer, we're able to remove some boilerplate. For example, in order to update our state, we would have to create a copy of our previous state and mutate the copy and return it. Instead, now we can just mutate state directly without the boilerplate and achieve our same results