### PR TITLE
Update Swift Package to be compatible with XCode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "ReactorKit",
   platforms: [
-    .macOS(.v10_11), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+    .macOS(.v10_11), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)
   ],
   products: [
     .library(name: "ReactorKit", targets: ["ReactorKit"]),


### PR DESCRIPTION
While building ReactorKit with Carthage using XCode 12, the build fails with a bunch of error messages about iOS 8 being an unsupported deployment target.  Increasing the deployment target to iOS 9 in the Swift Package definition file resolves the issue.

```
warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99. (in target 'RxSwift' from project 'ReactorKit')
warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99. (in target 'ReactorKitRuntime' from project 'ReactorKit')
** ARCHIVE FAILED **


The following build commands failed:
	CompileSwift normal armv7
	CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler
	CompileSwift normal arm64
(3 failures)
```