### PR TITLE
Remove RxExpect dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "RxExpect",
-        "repositoryURL": "https://github.com/devxoul/RxExpect.git",
-        "state": {
-          "branch": null,
-          "revision": "c3a3bb3d46ee831582c6619ecc48cda1cdbff890",
-          "version": "2.0.0"
-        }
-      },
-      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,12 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
-    .package(url: "https://github.com/ReactorKit/WeakMapTable.git", .upToNextMajor(from: "1.1.0")),
-    .package(url: "https://github.com/devxoul/RxExpect.git", .upToNextMajor(from: "2.0.0"))
+    .package(url: "https://github.com/ReactorKit/WeakMapTable.git", .upToNextMajor(from: "1.1.0"))
   ],
   targets: [
     .target(name: "ReactorKit", dependencies: ["ReactorKitRuntime", "RxSwift", "WeakMapTable"]),
     .target(name: "ReactorKitRuntime", dependencies: []),
-    .testTarget(name: "ReactorKitTests", dependencies: ["ReactorKit", "RxExpect"]),
+    .testTarget(name: "ReactorKitTests", dependencies: ["ReactorKit", "RxTest"]),
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -323,22 +323,32 @@ func testIsBookmarked() {
 }
 ```
 
-Sometimes a state is changed more than one time for a single action. For example, a `.refresh` action sets `state.isLoading` to `true` at first and sets to `false` after the refreshing. In this case it's difficult to test `state.isLoading` with `currentState` so you might need to use [RxTest](https://github.com/ReactiveX/RxSwift) or [RxExpect](https://github.com/devxoul/RxExpect). Here is an example test case using RxExpect:
+Sometimes a state is changed more than one time for a single action. For example, a `.refresh` action sets `state.isLoading` to `true` at first and sets to `false` after the refreshing. In this case it's difficult to test `state.isLoading` with `currentState` so you might need to use [RxTest](https://github.com/ReactiveX/RxSwift) or [RxExpect](https://github.com/devxoul/RxExpect). Here is an example test case using RxSwift:
 
 ```swift
 func testIsLoading() {
-  RxExpect("it should change isLoading") { test in
-    let reactor = test.retain(MyReactor())
-    test.input(reactor.action, [
-      next(100, .refresh) // send .refresh at 100 scheduler time
+  // given
+  let scheduler = TestScheduler(initialClock: 0)
+  let reactor = MyReactor()
+  let disposeBag = DisposeBag()
+
+  // when
+  scheduler
+    .createHotObservable([
+      .next(100, .refresh) // send .refresh at 100 scheduler time
     ])
-    test.assert(reactor.state.map { $0.isLoading })
-      .since(100) // values since 100 scheduler time
-      .assert([
-        true,  // just after .refresh
-        false, // after refreshing
-      ])
+    .subscribe(reactor.action)
+    .disposed(by: disposeBag)
+
+  // then
+  let response = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
+    reactor.state.map(\.isLoading)
   }
+  XCTAssertEqual(response.events.map(\.value.element), [
+    false, // initial state
+    true,  // just after .refresh
+    false  // after refreshing
+  ])
 }
 ```
 

--- a/Tests/ReactorKitTests/ActionSubjectTests.swift
+++ b/Tests/ReactorKitTests/ActionSubjectTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import RxExpect
 import RxSwift
 import RxTest
 @testable import ReactorKit
@@ -18,51 +17,75 @@ final class ActionSubjectTests: XCTestCase {
   }
 
   func testEmitNexts() {
-    let test = RxExpect()
+    // given
     let subject = ActionSubject<Int>()
-    test.input(subject, [
-      .next(100, 1),
-      .next(200, 2),
-      .next(300, 3),
-    ])
-    test.assert(subject) { events in
-      XCTAssertEqual(events, [
+    let scheduler = TestScheduler(initialClock: 0)
+    let disposeBag = DisposeBag()
+
+    // when
+    scheduler
+      .createHotObservable([
         .next(100, 1),
         .next(200, 2),
         .next(300, 3),
       ])
-    }
+      .subscribe(subject)
+      .disposed(by: disposeBag)
+
+    // then
+    let response = scheduler.start(created: 0, subscribed: 0, disposed: 1000) { subject.asObservable() }
+    XCTAssertEqual(response.events, [
+      .next(100, 1),
+      .next(200, 2),
+      .next(300, 3),
+    ])
   }
 
   func testIgnoreError() {
-    let test = RxExpect()
+    // given
     let subject = ActionSubject<Int>()
-    test.input(subject, [
-      .next(100, 1),
-      .error(200, TestError()),
-      .next(300, 3),
-    ])
-    test.assert(subject) { events in
-      XCTAssertEqual(events, [
+    let scheduler = TestScheduler(initialClock: 0)
+    let disposeBag = DisposeBag()
+
+    // when
+    scheduler
+      .createHotObservable([
         .next(100, 1),
+        .error(200, TestError()),
         .next(300, 3),
       ])
-    }
+      .subscribe(subject)
+      .disposed(by: disposeBag)
+
+    // then
+    let response = scheduler.start(created: 0, subscribed: 0, disposed: 1000) { subject.asObservable() }
+    XCTAssertEqual(response.events, [
+      .next(100, 1),
+      .next(300, 3),
+    ])
   }
 
   func testIgnoreCompleted() {
-    let test = RxExpect()
+    // given
     let subject = ActionSubject<Int>()
-    test.input(subject, [
-      .next(100, 1),
-      .completed(200),
-      .next(300, 3),
-    ])
-    test.assert(subject) { events in
-      XCTAssertEqual(events, [
+    let scheduler = TestScheduler(initialClock: 0)
+    let disposeBag = DisposeBag()
+
+    // when
+    scheduler
+      .createHotObservable([
         .next(100, 1),
+        .completed(200),
         .next(300, 3),
       ])
-    }
+      .subscribe(subject)
+      .disposed(by: disposeBag)
+
+    // then
+    let response = scheduler.start(created: 0, subscribed: 0, disposed: 1000) { subject.asObservable() }
+    XCTAssertEqual(response.events, [
+      .next(100, 1),
+      .next(300, 3),
+    ])
   }
 }

--- a/Tests/ReactorKitTests/StateRelayTests.swift
+++ b/Tests/ReactorKitTests/StateRelayTests.swift
@@ -6,9 +6,7 @@
 //
 
 import XCTest
-import RxExpect
 import RxSwift
-import RxTest
 @testable import ReactorKit
 
 class StateRelayTests: XCTestCase {


### PR DESCRIPTION
# Why remove?

RxExpect is third-party dependency and it has RxSwift dependency.
So, RxExpect must be updated first before ReactorKit's RxSwift version can be updated.
