### PR TITLE
Swizzle viewDidLoad in +load rather than +initialize.

### DIFF
--- a/Sources/ReactorKitRuntime/ReactorKitRuntime.m
+++ b/Sources/ReactorKitRuntime/ReactorKitRuntime.m
@@ -6,35 +6,18 @@
 + (void)load {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    [self swizzleInitializeOfClassNamed:@"UIViewController"];
+    [self swizzleViewDidLoadOfClassNamed:@"UIViewController"];
     #if !TARGET_OS_MACCATALYST
-    [self swizzleInitializeOfClassNamed:@"NSViewController"];
+    [self swizzleViewDidLoadOfClassNamed:@"NSViewController"];
     #endif
   });
 }
 
-+ (void)swizzleInitializeOfClassNamed:(NSString *)className {
++ (void)swizzleViewDidLoadOfClassNamed:(NSString *)className {
   Class class = NSClassFromString(className);
   if (!class) {
     return;
   }
-  method_exchangeImplementations(class_getClassMethod(class, @selector(initialize)),
-                                 class_getClassMethod(self, @selector(_reactorkit_initialize)));
-}
-
-+ (void)_reactorkit_initialize {
-  [self _reactorkit_initialize];
-  BOOL isUIViewController = [self isSubclassOfClassNamed:@"UIViewController"];
-  BOOL isNSViewController = [self isSubclassOfClassNamed:@"NSViewController"];
-  if (!isUIViewController && !isNSViewController) {
-    return;
-  }
-  [self swizzleViewDidLoad];
-}
-
-+ (void)swizzleViewDidLoad {
-  Class class = self;
-
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wundeclared-selector"
   SEL oldSelector = @selector(viewDidLoad);


### PR DESCRIPTION
My app using ReactorKit got crashed when previewing SwiftUI with infinite call to +initialize:

![截屏2021-06-22 上午12 52 49](https://user-images.githubusercontent.com/8158163/122799374-3b14bc80-d2f4-11eb-974c-f4c7d7e19b75.png)

By swizzle viewDidLoad in +load rather than +initialize, this issue can be solved. BTW, according to [NSHipster](https://nshipster.com/method-swizzling/#load-vs-initialize), swizzling in +initialize should be avoided.