### PR TITLE
Fix deprecated class type to AnyObject type

### DIFF
--- a/Sources/ReactorKit/IdentityEquatable.swift
+++ b/Sources/ReactorKit/IdentityEquatable.swift
@@ -5,7 +5,7 @@
 //  Created by Suyeol Jeon on 2019/10/17.
 //
 
-public protocol IdentityEquatable: class, Equatable {
+public protocol IdentityEquatable: AnyObject, Equatable {
 }
 
 public extension IdentityEquatable {

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -19,7 +19,7 @@ public typealias NoMutation = Never
 /// reactor is to separate control flow from a view. Every view has its corresponding reactor and
 /// delegates all logic to its reactor. A reactor has no dependency to a view, so it can be easily
 /// tested.
-public protocol Reactor: class {
+public protocol Reactor: AnyObject {
   /// An action represents user actions.
   associatedtype Action
 

--- a/Sources/ReactorKit/View.swift
+++ b/Sources/ReactorKit/View.swift
@@ -18,7 +18,7 @@ private enum MapTables {
 /// A View displays data. A view controller and a cell are treated as a view. The view binds user
 /// inputs to the action stream and binds the view states to each UI component. There's no business
 /// logic in a view layer. A view just defines how to map the action stream and the state stream.
-public protocol View: class {
+public protocol View: AnyObject {
   associatedtype Reactor: ReactorKit.Reactor
 
   /// A dispose bag. It is disposed each time the `reactor` is assigned.


### PR DESCRIPTION
Fix deprecated class type to AnyObject type

`class` and `AnyObject` are parses identically.

`class` display some warnings because it is deprecated.

![image](https://user-images.githubusercontent.com/27457243/124434119-7613f700-ddae-11eb-80fc-e14079120b49.png)


Ref: https://forums.swift.org/t/class-only-protocols-class-vs-anyobject/11507/10

## Before
```swift
public protocol IdentityEquatable: class, Equatable {
  // ...
}
```

## After
```swift
public protocol IdentityEquatable: AnyObject, Equatable {
  // ...
}
```