### PR TITLE
Add state(_:) to use KeyPath

### DIFF
--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -153,6 +153,10 @@ extension Reactor {
     return transformedState
   }
 
+  public func state<Result>(_ transform: @escaping (State) throws -> Result) -> Observable<Result> {
+    return self.state.map(transform)
+  }
+
   public func transform(action: Observable<Action>) -> Observable<Action> {
     return action
   }


### PR DESCRIPTION
Add `state(_:)` using `KeyPath`.  
Inspired by #176 [tokijh's Pulse](https://github.com/ReactorKit/ReactorKit/pull/176)  implementation.  

It can write a little less code using `KeyPath`.  

## Reactor
```swift
final class FooReactor: Reactor {
  enum Action {
    case increase
  }

  enum Mutation {
    case increaseValue
  }

  struct State {
    var value: Int
  }

  func mutate(action: Action) -> Observable<Mutation> {
    switch action {
      case .increase:
        return Observable.just(Mutation.increaseValue)
    }
  }

  func reduce(state: State, mutation: Mutation) -> State {
    var newState = state
    switch mutation {
    case .increaseValue:
      newState.value += 1
    }

    return newState
  }
}
```

## View

### Before
```swift
reactor.state.map(\.value)
  .subscribe(onNext: value in
    print(value)
  })
  .disposed(by: disposeBag)

reactor.action.onNext(.increase) // print '1'
reactor.action.onNext(.increase) // print '2'
```

### After
```swift
reactor.state(\.value)
  .subscribe(onNext: value in
    print(value)
  })
  .disposed(by: disposeBag)

reactor.action.onNext(.increase) // print '1'
reactor.action.onNext(.increase) // print '2'
```

---

```swift
// Pulse
reactor.pulse(\.$alertMessage)
  .compactMap { $0 }
  .subscribe(onNext: { [weak self] (message: String) in
    self?.showAlert(message)
  })
  .disposed(by: disposeBag)

// Using KeyPath State(_:) 
reactor.state(\.value)
  .subscribe(onNext: value in
    print(value)
  })
  .disposed(by: disposeBag)
```

With #176 [Pulse](https://github.com/ReactorKit/ReactorKit/pull/176),  
it becomes a more consistent code!