### PR TITLE
Add "Distinct" property wrapper

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/ReactorKit/Distinct.swift
+++ b/Sources/ReactorKit/Distinct.swift
@@ -1,0 +1,65 @@
+//
+//  Distinct.swift
+//  ReactorKit
+//
+//  Created by Haeseok Lee on 2022/03/20.
+//
+
+import Foundation
+
+@propertyWrapper
+public struct Distinct<Value: Hashable> {
+  
+  private let id: UUID = UUID()
+  
+  public var value: Value
+  
+  public var storedHashValue: Int? {
+    HashableStateCacheManager.lookUp(key: id)
+  }
+  
+  public var isDirty: Bool {
+    get {
+      let newHashValue = self.value.hashValue
+      let oldHashValue = self.storedHashValue
+      if newHashValue != oldHashValue {
+        HashableStateCacheManager.store(key: self.id, value: newHashValue)
+        return true
+      }
+      return false
+    }
+  }
+  
+  public var wrappedValue: Value {
+    get { self.value }
+    set { self.value = newValue }
+  }
+  
+  public init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+  
+  public var projectedValue: Distinct<Value> {
+    return self
+  }
+}
+
+fileprivate struct HashableStateCacheManager {
+  
+  private typealias HashID = NSNumber
+  private typealias HashValue = NSNumber
+  private static let shared: NSCache<HashID, HashValue> = NSCache<HashID, HashValue>()
+  
+  static func lookUp(key: UUID) -> Int? {
+    let key = NSNumber(value: key.hashValue)
+    if let hashValue = HashableStateCacheManager.shared.object(forKey: key) {
+      return hashValue as? Int
+    }
+    return nil
+  }
+  
+  static func store(key: UUID, value: Int) {
+    let (key, value) = (NSNumber(value: key.hashValue), NSNumber(value: value))
+    shared.setObject(value, forKey: key)
+  }
+}

--- a/Sources/ReactorKit/Reactor+Distinct.swift
+++ b/Sources/ReactorKit/Reactor+Distinct.swift
@@ -1,0 +1,14 @@
+//
+//  Reactor+Distinct.swift
+//  ReactorKit
+//
+//  Created by Haeseok Lee on 2022/03/20.
+//
+
+import Foundation
+
+extension Reactor {
+  public func state<Result: Hashable>(_ transformToDistinct: @escaping (State) throws -> Distinct<Result>) -> Observable<Result> {
+    return self.state.map(transformToDistinct).filter(\.isDirty).map(\.value)
+  }
+}

--- a/Tests/ReactorKitTests/DistinctTests.swift
+++ b/Tests/ReactorKitTests/DistinctTests.swift
@@ -1,0 +1,62 @@
+//
+//  DistinctTests.swift
+//  ReactorKitTests
+//
+//  Created by Haeseok Lee on 2022/03/20.
+//
+
+import XCTest
+import RxSwift
+@testable import ReactorKit
+
+final class DistinctTests: XCTestCase {
+  func testIsDirtyIsTrueWhenFirstLoaded() {
+    // given
+    struct State {
+      @Distinct var value: Int = 0
+    }
+
+    // when
+    let state = State()
+    
+    // then
+    XCTAssertTrue(state.$value.isDirty)
+  }
+
+  func testIsDirtyIsTrueWhenNewValueAssigned() {
+    // given
+    struct State {
+      @Distinct var value: Int = 0
+    }
+    
+    // when & then
+    var state = State()
+    state.value = 10 // assign new value
+    XCTAssertTrue(state.$value.isDirty)
+    
+    state.value = 20 // assign new value
+    XCTAssertTrue(state.$value.isDirty)
+    
+    state.value = 30 // assign new value
+    XCTAssertTrue(state.$value.isDirty)
+    
+  }
+  
+  func testIsDirtyIsFalseWhenSameValueAssigned() {
+    // given
+    struct State {
+      @Distinct var value: Int = 0
+    }
+    
+    // when & then
+    var state = State()
+    state.value = 10 // assign new value
+    XCTAssertTrue(state.$value.isDirty)
+    
+    state.value = 10 // assign same value
+    XCTAssertFalse(state.$value.isDirty)
+    
+    state.value = 10 // assign same value
+    XCTAssertFalse(state.$value.isDirty)
+  }
+}

--- a/Tests/ReactorKitTests/Reactor+DistinctTests.swift
+++ b/Tests/ReactorKitTests/Reactor+DistinctTests.swift
@@ -1,0 +1,124 @@
+//
+//  Reactor+DistinctTests.swift
+//  ReactorKitTests
+//
+//  Created by Haeseok Lee on 2022/03/20.
+//
+
+import XCTest
+import RxSwift
+@testable import ReactorKit
+
+final class Reactor_DistinctTests: XCTestCase {
+  
+  func testDistinct() {
+    // given
+    let reactor = TestReactor(section: Section(items: ["a", "b", "c"]))
+    let disposeBag = DisposeBag()
+    var sectionUpdatedCounter = 0
+    var titleUpdatedCounter = 0
+    
+    reactor.state(\.$section)
+      .subscribe(onNext: { section in
+        sectionUpdatedCounter += 1
+      })
+      .disposed(by: disposeBag)
+    
+    reactor.state(\.$title)
+      .subscribe(onNext: { title in
+        titleUpdatedCounter += 1
+      })
+      .disposed(by: disposeBag)
+    
+    // when
+    reactor.action.onNext(.updateSectionItems(["a", "b", "c"])) // don't render section
+    reactor.action.onNext(.increaseCount)                       // don't render section & title
+    reactor.action.onNext(.updateSectionItems(["a"]))           // render section
+    reactor.action.onNext(.updateSectionItems(["a"]))           // don't render section
+    
+    reactor.action.onNext(.updateTitle("title"))                // render title
+    reactor.action.onNext(.updateTitle("new title"))            // render title
+    reactor.action.onNext(.increaseCount)                       // don't render section & title
+    reactor.action.onNext(.updateTitle("new title"))            // don't render title
+
+    // then
+    XCTAssertEqual(sectionUpdatedCounter, 2)                    // first section rendering + 1
+    XCTAssertEqual(titleUpdatedCounter, 3)                      // first title rendering + 2
+    
+    XCTAssertEqual(reactor.currentState.section.items, ["a"])
+    XCTAssertEqual(reactor.currentState.title, "new title")
+    XCTAssertEqual(reactor.currentState.count, 2)
+  }
+}
+
+fileprivate final class TestReactor: Reactor {
+  
+  enum Action {
+    case updateSectionItems([Section.Item])
+    case updateTitle(String)
+    case increaseCount
+  }
+
+  enum Mutation {
+    case setSectionItems([Section.Item])
+    case setTitle(String)
+    case increaseCount
+  }
+
+  struct State {
+    @Distinct var section: Section
+    @Distinct var title: String?
+    var count: Int = 0
+  }
+
+  let initialState: State
+  
+  init(section: Section) {
+    initialState = State(section: section)
+  }
+  
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case let .updateSectionItems(items):
+      return Observable.just(Mutation.setSectionItems(items))
+    case let .updateTitle(title):
+      return Observable.just(Mutation.setTitle(title))
+    case .increaseCount:
+      return Observable.just(Mutation.increaseCount)
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+
+    switch mutation {
+    case let .setSectionItems(items):
+      newState.section.items = items
+    case let .setTitle(title):
+      newState.title = title
+    case .increaseCount:
+      newState.count += 1
+    }
+
+    return newState
+  }
+}
+
+fileprivate class Section: Hashable {
+  
+  typealias Item = String
+  
+  static func == (lhs: Section, rhs: Section) -> Bool {
+    lhs.hashValue == rhs.hashValue
+  }
+  
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(items)
+  }
+  
+  var items: [Item]
+  
+  init(items: [Item]) {
+    self.items = items
+  }
+}


### PR DESCRIPTION
### Motivation

Observer subscribing to the reactor state causes unnecessary view re-rendering when the `distinctUntilChanged` operator is not applied. 

```Swift
class TestReactor: Reactor {
  
  struct State {
    var items: [String] = ["a", "b", "c"]
  }
}
```

```Swift
class TestViewController: UIViewController, View {

  func bind(reactor: TestReactor) {
    reactor.state
      .map { $0.items }
      .distinctUntilChanged()
      .subscribe(onNext: { items in
        // 🤔 If distinctUntilchanged is not applied, there is a problem that duplicate data comes in.
        // And it is not compulsory and may be omitted by mistake.
      })
      .disposed(by: disposeBag)
  }
}
```

Therefore, in order to prevent unnecessary re-rendering, this problem must be prevented during the property declaration phase. This idea was inspired by `Pulse`.  Thanks to @tokijh 

### Feature

Therefore, introduce a property wrapper called `Distinct`.

Property wrapped in `Distinct` can be obtained through `state` method and `keyPath`. At this time, it is executed only when the value changes, and the above-mentioned problems can be solved. This method simplifies state subscriptions and is more intuitive.

```Swift
// before
reactor.state.map { $0.value }.distinctUntilChanged()
```

```Swift
// after
reactor.state(\.$value) 
```

In order to apply `Distinct` property wrappers, the type of property must be hashable.
Here's an improved code.

```Swift
class TestReactor: Reactor {
  
  struct State {
    @Distinct var items: [String] = ["a", "b", "c"]
  }
}
```

```Swift
class TestViewController: UIViewController, View {

  func bind(reactor: TestReactor) {
    reactor.state(\.$items)
      .subscribe(onNext: { items in
        // ✅ Except for the first run, it only works when the value changes.
      })
      .disposed(by: disposeBag)
  }
}
```

