### PR TITLE
Renamed public protocol 'View' to 'ReactorView'

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You may want to see the [Examples](#examples) section first if you'd like to see
 - [Table of Contents](#table-of-contents)
 - [Basic Concept](#basic-concept)
   - [Design Goal](#design-goal)
-  - [View](#view)
+  - [ReactorView](#reactorview)
     - [Storyboard Support](#storyboard-support)
   - [Reactor](#reactor)
     - [`mutate()`](#mutate)
@@ -66,14 +66,14 @@ ReactorKit is a combination of [Flux](https://facebook.github.io/flux/) and [Rea
 * **Start Small**: ReactorKit doesn't require the whole application to follow a single architecture. ReactorKit can be adopted partially, for one or more specific views. You don't need to rewrite everything to use ReactorKit on your existing project.
 * **Less Typing**: ReactorKit focuses on avoiding complicated code for a simple thing. ReactorKit requires less code compared to other architectures. Start simple and scale up.
 
-### View
+### ReactorView
 
-A *View* displays data. A view controller and a cell are treated as a view. The view binds user inputs to the action stream and binds the view states to each UI component. There's no business logic in a view layer. A view just defines how to map the action stream and the state stream.
+A *ReactorView* displays data. A view controller and a cell are treated as a view. The view binds user inputs to the action stream and binds the view states to each UI component. There's no business logic in a view layer. A view just defines how to map the action stream and the state stream.
 
 To define a view, just have an existing class conform a protocol named `View`. Then your class will have a property named `reactor` automatically. This property is typically set outside of the view.
 
 ```swift
-class ProfileViewController: UIViewController, View {
+class ProfileViewController: UIViewController, ReactorView {
   var disposeBag = DisposeBag()
 }
 

--- a/Sources/ReactorKit/ReactorView.swift
+++ b/Sources/ReactorKit/ReactorView.swift
@@ -18,7 +18,7 @@ private enum MapTables {
 /// A View displays data. A view controller and a cell are treated as a view. The view binds user
 /// inputs to the action stream and binds the view states to each UI component. There's no business
 /// logic in a view layer. A view just defines how to map the action stream and the state stream.
-public protocol View: AnyObject {
+public protocol ReactorView: AnyObject {
   associatedtype Reactor: ReactorKit.Reactor
 
   /// A dispose bag. It is disposed each time the `reactor` is assigned.
@@ -51,7 +51,7 @@ public protocol View: AnyObject {
 
 // MARK: - Default Implementations
 
-extension View {
+extension ReactorView {
   public var reactor: Reactor? {
     get { return MapTables.reactor.value(forKey: self) as? Reactor }
     set {

--- a/Sources/ReactorKit/StoryboardView.swift
+++ b/Sources/ReactorKit/StoryboardView.swift
@@ -21,7 +21,7 @@ public protocol _ObjCStoryboardView {
   func performBinding()
 }
 
-public protocol StoryboardView: View, _ObjCStoryboardView {
+public protocol StoryboardView: ReactorView, _ObjCStoryboardView {
 }
 
 extension StoryboardView {

--- a/Tests/ReactorKitTests/ViewTests.swift
+++ b/Tests/ReactorKitTests/ViewTests.swift
@@ -99,7 +99,7 @@ final class ViewTests: XCTestCase {
   }
 }
 
-private final class TestView: View {
+private final class TestView: ReactorView {
   var disposeBag = DisposeBag()
   var bindInvokeCount = 0
 


### PR DESCRIPTION
It was clashing with SwiftUI's public protocol named 'View'. 

SwiftUI's public protocol: https://developer.apple.com/documentation/swiftui/view

Motivation:

It was discovered that views on UIKit can be previewed on real time without building the project every time same as in projects which are built on SwiftUI.

However, current version of ReactorKit has the same named public protocol for the UIViewControllers to inherit Reactor automatically. 
I renamed the protocol from 'View' to 'ReactorView', which should solve the issue. 

