### PR TITLE
Added code to remove optinal when using Pulse

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/ReactorKit/Reactor+Pulse.swift
+++ b/Sources/ReactorKit/Reactor+Pulse.swift
@@ -9,4 +9,8 @@ extension Reactor {
   public func pulse<Result>(_ transformToPulse: @escaping (State) throws -> Pulse<Result>) -> Observable<Result> {
     return self.state.map(transformToPulse).distinctUntilChanged(\.valueUpdatedCount).map(\.value)
   }
+  public func pulseNil<Result>(_ transformToPulse: @escaping (State) throws -> Pulse<Result?>) -> Observable<Result> {
+    let pulse = self.state.map(transformToPulse).distinctUntilChanged(\.valueUpdatedCount).map(\.value)
+    return pulse.compactMap { $0 }
+  }
 }

--- a/Tests/ReactorKitTests/Reactor+PulseTests.swift
+++ b/Tests/ReactorKitTests/Reactor+PulseTests.swift
@@ -43,6 +43,39 @@ final class Reactor_PulseTests: XCTestCase {
     ])
     XCTAssertEqual(reactor.currentState.count, 2)
   }
+    
+  func testPulseNil() {
+      // given
+    let reactor = TestReactor()
+    let disposeBag = DisposeBag()
+    var receivedAlertMessages: [String] = []
+
+    reactor.pulseNil(\.$alertMessage)
+    .subscribe(onNext: { alertMessage in
+        receivedAlertMessages.append(alertMessage)
+    })
+    .disposed(by: disposeBag)
+
+    // when
+    reactor.action.onNext(.showAlert(message: "1")) // alert '1'
+    reactor.action.onNext(.increaseCount)           // ignore
+    reactor.action.onNext(.showAlert(message: nil)) // ignore
+    reactor.action.onNext(.showAlert(message: "2")) // alert '2'
+    reactor.action.onNext(.showAlert(message: nil)) // ignore
+    reactor.action.onNext(.increaseCount)           // ignore
+    reactor.action.onNext(.showAlert(message: nil)) // ignore
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+
+    // then
+    XCTAssertEqual(receivedAlertMessages, [
+          "1",
+          "2",
+          "3",
+          "3",
+    ])
+    XCTAssertEqual(reactor.currentState.count, 2)
+  }
 }
 
 private final class TestReactor: Reactor {


### PR DESCRIPTION
Many people are using the compactMap by adding one more time to the code stage to remove the optinal when using ReactorKit's Pulse. To improve this part, I made it into its own function.