### PR TITLE
Update deprecated bash uploader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
           SDK: ${{ matrix.env.sdk }}
           DESTINATION: ${{ matrix.env.destination }}
 
-      - name: Upload Code Coverage
-        run: |
-          bash <(curl -s https://codecov.io/bash) \
-            -X xcodeplist \
-            -J "$CODECOV_PACKAGE_NAME" \
-            -t ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          xcode: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
             -destination "$DESTINATION" \
             -configuration Debug \
             -enableCodeCoverage YES \
+            -resultBundlePath "./${{ matrix.env.sdk }}.xcresult" \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c;
         env:
           SDK: ${{ matrix.env.sdk }}
@@ -51,3 +52,4 @@ jobs:
         uses: codecov/codecov-action@v3.1.0
         with:
           xcode: true
+          xcode_archive_path: "./${{ matrix.env.sdk }}.xcresult"


### PR DESCRIPTION
[Codecov bash uploader was deprecated](https://docs.codecov.com/docs/about-the-codecov-bash-uploader)
Accordingly, changed it to [Codecov Uploader](https://github.com/marketplace/actions/codecov). (fd85ca48e45be15214c803567a34208e82c2a8c0) 
Changes to xcode support for codecov-action v3 have also been added. (141a2f5d08dbf83bc0676bf3b9907ea4a73142c9)

Ref: https://docs.codecov.com/docs/codecov-uploader