### PR TITLE
Update podfile iPhone deployment target && Counter target 11.0

### DIFF
--- a/Examples/Counter/Counter.xcodeproj/project.pbxproj
+++ b/Examples/Counter/Counter.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Counter/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Counter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -414,6 +415,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Counter/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = kr.xoul.Counter;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/Podfile
+++ b/Examples/Podfile
@@ -21,7 +21,7 @@ post_install do |installer|
     installer.generated_projects.each do |project|
           project.targets.each do |target|
               target.build_configurations.each do |config|
-                  config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+                  config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
                end
           end
    end

--- a/Examples/Podfile
+++ b/Examples/Podfile
@@ -16,3 +16,13 @@ abstract_target 'Example' do
     project 'GitHubSearch/GitHubSearch.xcodeproj'
   end
 end
+
+post_install do |installer|
+    installer.generated_projects.each do |project|
+          project.targets.each do |target|
+              target.build_configurations.each do |config|
+                  config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+               end
+          end
+   end
+end


### PR DESCRIPTION
Since the minimum target version of Reactorkit is 11, i modified the target of the Counter example project from 10.3 to 11.
Xcode 14 only supports building for a deployment target of iOS 11. Fixed a part where an error that requires reference to the "libarclite" library occurs.