### PR TITLE
feat: remove scheduler in Reactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,22 +363,6 @@ func testIsLoading() {
 }
 ```
 
-### Scheduling
-
-Define `scheduler` property to specify which scheduler is used for observing the state stream. Note that this queue **must be** a serial queue. The default scheduler is `MainScheduler`.
-
-```swift
-final class MyReactor: Reactor {
-  let scheduler: Scheduler = SerialDispatchQueueScheduler(qos: .default)
-
-  func reduce(state: State, mutation: Mutation) -> State {
-    // executed in a background thread
-    heavyAndImportantCalculation()
-    return state
-  }
-}
-```
-
 ### Pulse
 
 `Pulse` has diff only when mutated

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -43,9 +43,6 @@ public protocol Reactor: AnyObject {
   /// The state stream. Use this observable to observe the state changes.
   var state: Observable<State> { get }
 
-  /// A scheduler for observing the state stream. Defaults to `MainScheduler`.
-  var scheduler: Scheduler { get }
-
   /// Transforms the action. Use this function to combine with other observables. This method is
   /// called once before the state stream is created.
   func transform(action: Observable<Action>) -> Observable<Action>
@@ -122,10 +119,6 @@ extension Reactor {
     _state
   }
 
-  public var scheduler: Scheduler {
-    MainScheduler.instance
-  }
-
   fileprivate var disposeBag: DisposeBag {
     MapTables.disposeBag.value(forKey: self, default: DisposeBag())
   }
@@ -152,7 +145,7 @@ extension Reactor {
       })
       .replay(1)
     transformedState.connect().disposed(by: disposeBag)
-    return transformedState.observe(on: scheduler)
+    return transformedState
   }
 
   public func transform(action: Observable<Action>) -> Observable<Action> {

--- a/Tests/ReactorKitTests/ReactorSchedulerTests.swift
+++ b/Tests/ReactorKitTests/ReactorSchedulerTests.swift
@@ -11,6 +11,7 @@ import ReactorKit
 import RxSwift
 
 final class ReactorSchedulerTests: XCTestCase {
+
   func testStateStreamIsCreatedOnce() {
     final class SimpleReactor: Reactor {
       typealias Action = Never
@@ -20,7 +21,6 @@ final class ReactorSchedulerTests: XCTestCase {
       let initialState: State = 0
 
       func transform(action: Observable<Action>) -> Observable<Action> {
-        sleep(5)
         return action
       }
     }
@@ -28,6 +28,7 @@ final class ReactorSchedulerTests: XCTestCase {
     let reactor = SimpleReactor()
     var states: [Observable<SimpleReactor.State>] = []
     let lock = NSLock()
+    let expectation = XCTestExpectation()
 
     for _ in 0..<100 {
       DispatchQueue.global().async {
@@ -35,139 +36,18 @@ final class ReactorSchedulerTests: XCTestCase {
         lock.lock()
         states.append(state)
         lock.unlock()
+
+        if states.count == 100 {
+          expectation.fulfill()
+        }
       }
     }
 
-    XCTWaiter().wait(for: [XCTestExpectation()], timeout: 10)
+    XCTWaiter().wait(for: [expectation], timeout: 10)
 
     XCTAssertGreaterThan(states.count, 0)
     for state in states {
       XCTAssertTrue(state === states.first)
     }
-  }
-
-  func testDefaultScheduler() {
-    final class SimpleReactor: Reactor {
-      typealias Action = Void
-      typealias Mutation = Void
-
-      struct State {
-        var reductionThreads: [Thread] = []
-      }
-
-      let initialState = State()
-
-      func reduce(state: State, mutation: Mutation) -> State {
-        var newState = state
-        let currentThread = Thread.current
-        newState.reductionThreads.append(currentThread)
-        return newState
-      }
-    }
-
-    let reactor = SimpleReactor()
-    let disposeBag = DisposeBag()
-
-    var observationThreads: [Thread] = []
-
-    var isExecuted = false
-
-    DispatchQueue.global().async {
-      let currentThread = Thread.current
-
-      reactor.state
-        .subscribe(onNext: { _ in
-          let currentThread = Thread.current
-          observationThreads.append(currentThread)
-        })
-        .disposed(by: disposeBag)
-
-      for _ in 0..<100 {
-        reactor.action.onNext(Void())
-      }
-
-      XCTWaiter().wait(for: [XCTestExpectation()], timeout: 1)
-
-      let reductionThreads = reactor.currentState.reductionThreads
-      XCTAssertEqual(reductionThreads.count, 100)
-      for thread in reductionThreads {
-        XCTAssertEqual(thread, currentThread)
-      }
-
-      XCTAssertEqual(observationThreads.count, 101) // +1 for initial state
-
-      // states are observed on the main thread.
-      for thread in observationThreads {
-        XCTAssertTrue(thread.isMainThread)
-      }
-
-      isExecuted = true
-    }
-
-    XCTWaiter().wait(for: [XCTestExpectation()], timeout: 1.5)
-    XCTAssertTrue(isExecuted)
-  }
-
-  func testCustomScheduler() {
-    final class SimpleReactor: Reactor {
-      typealias Action = Void
-      typealias Mutation = Void
-
-      struct State {
-        var reductionThreads: [Thread] = []
-      }
-
-      let initialState = State()
-      let scheduler: ImmediateSchedulerType = SerialDispatchQueueScheduler(qos: .default)
-
-      func reduce(state: State, mutation: Mutation) -> State {
-        var newState = state
-        let currentThread = Thread.current
-        newState.reductionThreads.append(currentThread)
-        return newState
-      }
-    }
-
-    let reactor = SimpleReactor()
-    let disposeBag = DisposeBag()
-
-    var observationThreads: [Thread] = []
-
-    var isExecuted = false
-
-    DispatchQueue.global().async {
-      let currentThread = Thread.current
-
-      reactor.state
-        .subscribe(onNext: { _ in
-          let currentThread = Thread.current
-          observationThreads.append(currentThread)
-        })
-        .disposed(by: disposeBag)
-
-      for _ in 0..<100 {
-        reactor.action.onNext(Void())
-      }
-
-      XCTWaiter().wait(for: [XCTestExpectation()], timeout: 1)
-
-      let reductionThreads = reactor.currentState.reductionThreads
-      XCTAssertEqual(reductionThreads.count, 100)
-      for thread in reductionThreads {
-        XCTAssertEqual(thread, currentThread)
-      }
-
-      XCTAssertEqual(observationThreads.count, 101) // +1 for initial state
-
-      // states are observed on the specified thread.
-      for thread in observationThreads {
-        XCTAssertNotEqual(thread, currentThread)
-      }
-
-      isExecuted = true
-    }
-
-    XCTWaiter().wait(for: [XCTestExpectation()], timeout: 1.5)
-    XCTAssertTrue(isExecuted)
   }
 }


### PR DESCRIPTION
When an action is sent to a reactor it is run on the current state and this process cannot be done from multiple threads

It is possible to make this process thread-safe by introducing scheduler, but this cause other problems

Those APIs tend to deliver their outputs on whatever thread is most convenient for them, and then it is your responsibility

ReactorKit makes you responsible for making sure to send actions on the main thread. If you may mutate states on a non-main thread, you must explicitly perform `.observe(on:)` in order to force it back on the main thread.