### PR TITLE
fix: lock access modifier and changed `var` to `let`

### DIFF
--- a/Sources/ReactorKit/ActionSubject.swift
+++ b/Sources/ReactorKit/ActionSubject.swift
@@ -14,7 +14,7 @@ import RxSwift
 public final class ActionSubject<Element>: ObservableType, ObserverType, SubjectType {
   typealias Key = UInt
 
-  var lock = NSRecursiveLock()
+  private let lock = NSRecursiveLock()
 
   var nextKey: Key = 0
   var observers: [Key: (Event<Element>) -> ()] = [:]


### PR DESCRIPTION
### Description
This pull request fixes the lock access modifier and changes var to let in the ActionSubject class.

### Changes
The lock access modifier is changed to private to ensure thread safety and changed from var to let to prevent accidental modification.

### Rationale
The original lock access modifier was public, which means that any code could access the lock. This could lead to race conditions if multiple threads were accessing the lock at the same time.

 also, lock property was var, which means that it could be modified by external code. This could lead to unexpected behavior if the value of lock was modified incorrectly.

By changing the lock access modifier to private and property to let, we can improve the thread safety and prevent accidental modification of the ActionSubject class