### PR TITLE
Update some minor codes and add comments

### DIFF
--- a/Sources/ReactorKit/ActionSubject.swift
+++ b/Sources/ReactorKit/ActionSubject.swift
@@ -16,7 +16,7 @@ public final class ActionSubject<Element>: ObservableType, ObserverType, Subject
 
   private let lock = NSRecursiveLock()
 
-  var nextKey: Key = 0
+  private var nextKey: Key = 0
   var observers: [Key: (Event<Element>) -> ()] = [:]
 
   #if TRACE_RESOURCES

--- a/Sources/ReactorKit/IdentityEquatable.swift
+++ b/Sources/ReactorKit/IdentityEquatable.swift
@@ -8,6 +8,8 @@
 public protocol IdentityEquatable: AnyObject, Equatable {}
 
 extension IdentityEquatable {
+  @inlinable
+  @inline(__always)
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs === rhs
   }

--- a/Sources/ReactorKit/IdentityHashable.swift
+++ b/Sources/ReactorKit/IdentityHashable.swift
@@ -8,6 +8,8 @@
 public protocol IdentityHashable: Hashable, IdentityEquatable {}
 
 extension IdentityHashable {
+  @inlinable
+  @inline(__always)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ObjectIdentifier(self).hashValue)
   }

--- a/Sources/ReactorKit/Reactor+Pulse.swift
+++ b/Sources/ReactorKit/Reactor+Pulse.swift
@@ -6,6 +6,14 @@
 //
 
 extension Reactor {
+  /// Returns an observable sequence that emits the value of the pulse only when its valueUpdatedCount changes.
+  ///
+  /// - seealso: [Pulse document](https://github.com/ReactorKit/ReactorKit/blob/master/Documentation/Contents/Pulse.md)
+  /// - seealso: [The official document introduction](https://github.com/ReactorKit/ReactorKit#pulse)
+  ///
+  /// - parameter transformToPulse: A transform function to apply to the current state of the reactor
+  /// to produce a pulse.
+  /// - returns: An observable that emits the value of the pulse whenever its valueUpdatedCount changes.
   public func pulse<Result>(_ transformToPulse: @escaping (State) throws -> Pulse<Result>) -> Observable<Result> {
     state.map(transformToPulse).distinctUntilChanged(\.valueUpdatedCount).map(\.value)
   }

--- a/Tests/ReactorKitTests/StateRelayTests.swift
+++ b/Tests/ReactorKitTests/StateRelayTests.swift
@@ -58,25 +58,25 @@ final class StateRelayTests: XCTestCase {
     var a = StateRelay(value: 1)
 
     var latest = 0
-    var completed = false
+    var isCompleted = false
     let disposable = a.asObservable().debug().subscribe(onNext: { n in
       latest = n
     }, onCompleted: {
-      completed = true
+      isCompleted = true
     })
 
     XCTAssertEqual(latest, 1)
-    XCTAssertFalse(completed)
+    XCTAssertFalse(isCompleted)
 
     a = StateRelay(value: 2)
 
     XCTAssertEqual(latest, 1)
-    XCTAssertFalse(completed)
+    XCTAssertFalse(isCompleted)
 
     disposable.dispose()
 
     XCTAssertEqual(latest, 1)
-    XCTAssertFalse(completed)
+    XCTAssertFalse(isCompleted)
   }
 
   func testVariableREADMEExampleByStateRelay() {


### PR DESCRIPTION
### Description
Update some minor codes for this projects

### Changes
1. nextKey property access modifier is changed to private 
2. add inline attribute on `==`, `hash` operations
3. fixes `Bool` variable in test 
4. add comments on pulse operation 

### Rationale
1. There was no need for the next key to be used without being used elsewhere except for `ActionSubject` class 
2. Performance improvement can be expected by adding inline attribute
ref: [https://forums.swift.org/t/when-should-both-inlinable-and-inline-always-be-used/37375](https://forums.swift.org/t/when-should-both-inlinable-and-inline-always-be-used/37375)