### PR TITLE
Update access modifier, add comment, and update variable naming

### DIFF
--- a/Sources/ReactorKit/ActionSubject.swift
+++ b/Sources/ReactorKit/ActionSubject.swift
@@ -16,7 +16,7 @@ public final class ActionSubject<Element>: ObservableType, ObserverType, Subject
 
   private let lock = NSRecursiveLock()
 
-  var nextKey: Key = 0
+  private var nextKey: Key = 0
   var observers: [Key: (Event<Element>) -> ()] = [:]
 
   #if TRACE_RESOURCES

--- a/Sources/ReactorKit/Reactor+Pulse.swift
+++ b/Sources/ReactorKit/Reactor+Pulse.swift
@@ -6,6 +6,14 @@
 //
 
 extension Reactor {
+  /// Returns an observable sequence that emits the value of the pulse only when its valueUpdatedCount changes.
+  ///
+  /// - seealso: [Pulse document](https://github.com/ReactorKit/ReactorKit/blob/master/Documentation/Contents/Pulse.md)
+  /// - seealso: [The official document introduction](https://github.com/ReactorKit/ReactorKit#pulse)
+  ///
+  /// - parameter transformToPulse: A transform function to apply to the current state of the reactor
+  /// to produce a pulse.
+  /// - returns: An observable that emits the value of the pulse whenever its valueUpdatedCount changes.
   public func pulse<Result>(_ transformToPulse: @escaping (State) throws -> Pulse<Result>) -> Observable<Result> {
     state.map(transformToPulse).distinctUntilChanged(\.valueUpdatedCount).map(\.value)
   }

--- a/Tests/ReactorKitTests/StateRelayTests.swift
+++ b/Tests/ReactorKitTests/StateRelayTests.swift
@@ -58,25 +58,25 @@ final class StateRelayTests: XCTestCase {
     var a = StateRelay(value: 1)
 
     var latest = 0
-    var completed = false
+    var isCompleted = false
     let disposable = a.asObservable().debug().subscribe(onNext: { n in
       latest = n
     }, onCompleted: {
-      completed = true
+      isCompleted = true
     })
 
     XCTAssertEqual(latest, 1)
-    XCTAssertFalse(completed)
+    XCTAssertFalse(isCompleted)
 
     a = StateRelay(value: 2)
 
     XCTAssertEqual(latest, 1)
-    XCTAssertFalse(completed)
+    XCTAssertFalse(isCompleted)
 
     disposable.dispose()
 
     XCTAssertEqual(latest, 1)
-    XCTAssertFalse(completed)
+    XCTAssertFalse(isCompleted)
   }
 
   func testVariableREADMEExampleByStateRelay() {


### PR DESCRIPTION
I remove Inline attribute commit from [here #221](https://github.com/ReactorKit/ReactorKit/pull/221#issue-1968352416)

### Change
- Update access modifier 
- Add comment for pulse operation
- Update Bool variable naming