### PR TITLE
Expose event stream

### DIFF
--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -96,15 +96,9 @@ extension Reactor {
       return MapTables.streams.forceCastedValue(forKey: self, default: createReactorStreams())
     }
   }
-  
-  private var _action: ActionSubject<Action> {
-    streams.action
-  }
 
   public var action: ActionSubject<Action> {
-    // It seems that Swift has a bug in associated object when subclassing a generic class. This is
-    // a temporary solution to bypass the bug. See #30 for details.
-    _action
+    streams.action
   }
 
   public internal(set) var currentState: State {
@@ -112,14 +106,8 @@ extension Reactor {
     set { MapTables.currentState.setValue(newValue, forKey: self) }
   }
 
-  private var _state: Observable<State> {
-    streams.state
-  }
-
   public var state: Observable<State> {
-    // It seems that Swift has a bug in associated object when subclassing a generic class. This is
-    // a temporary solution to bypass the bug. See #30 for details.
-    _state
+    streams.state
   }
 
   fileprivate var disposeBag: DisposeBag {

--- a/Tests/ReactorKitTests/ReactorEventTests.swift
+++ b/Tests/ReactorKitTests/ReactorEventTests.swift
@@ -1,0 +1,195 @@
+//
+//  Reactor+PulseTests.swift
+//  ReactorKit
+//
+//  Created by 김동현 on 2024/02/11.
+//
+
+import XCTest
+
+import RxSwift
+@testable import ReactorKit
+
+final class Reactor_EventTests: XCTestCase {
+  func testReceiveAllEventsCorrectly() {
+    // given
+    let reactor = TestReactor()
+    let disposeBag = DisposeBag()
+    var receivedEvents: [TestReactor.Event] = []
+    
+    reactor.event
+      .subscribe(onNext: { receivedEvents.append($0) })
+      .disposed(by: disposeBag)
+    
+    // when
+    reactor.action.onNext(.showAlert(message: "1")) // alert '1'
+    reactor.action.onNext(.increaseCount) // ignore
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.showAlert(message: "2")) // alert '2'
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.increaseCount) // ignore
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+
+    // then
+    XCTAssertEqual(receivedEvents, [
+      TestReactor.Event.alertMessageDidChange("1"),
+      TestReactor.Event.countDidIncrease,
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.alertMessageDidChange("2"),
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.countDidIncrease,
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.alertMessageDidChange("3"),
+      TestReactor.Event.alertMessageDidChange("3"),
+    ])
+    XCTAssertEqual(reactor.currentState.count, 2)
+  }
+  
+  func testReceiveAllEventsPublishedAfterSubscribe() {
+    // given
+    let reactor = TestReactor()
+    let disposeBag = DisposeBag()
+    var receivedEvents: [TestReactor.Event] = []
+
+    reactor.action.onNext(.showAlert(message: "1")) // alert '1'
+    reactor.action.onNext(.increaseCount) // ignore
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.showAlert(message: "2")) // alert '2'
+
+    reactor.event
+      .subscribe(onNext: { receivedEvents.append($0) })
+      .disposed(by: disposeBag)
+
+    // when
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.increaseCount) // ignore
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+
+    // then
+    XCTAssertEqual(receivedEvents, [
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.countDidIncrease,
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.alertMessageDidChange("3"),
+      TestReactor.Event.alertMessageDidChange("3"),
+    ])
+    XCTAssertEqual(reactor.currentState.count, 2)
+  }
+  
+  func testMultipleSubscriptionShouldReceiveAllEventsPublishedAfterSubscribe() {
+    // given
+    let reactor = TestReactor()
+    let disposeBag = DisposeBag()
+    var receivedEvents1: [TestReactor.Event] = []
+    var receivedEvents2: [TestReactor.Event] = []
+    var receivedEvents3: [TestReactor.Event] = []
+    
+    reactor.event
+      .subscribe(onNext: { receivedEvents1.append($0) })
+      .disposed(by: disposeBag)
+    
+    reactor.action.onNext(.showAlert(message: "1")) // alert '1'
+    reactor.action.onNext(.increaseCount) // ignore
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.showAlert(message: "2")) // alert '2'
+    
+    reactor.event
+      .subscribe(onNext: { receivedEvents2.append($0) })
+      .disposed(by: disposeBag)
+    
+    reactor.event
+      .subscribe(onNext: { receivedEvents3.append($0) })
+      .disposed(by: disposeBag)
+
+    // when
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.increaseCount) // ignore
+    reactor.action.onNext(.closeAlert) // ignore
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+    reactor.action.onNext(.showAlert(message: "3")) // alert '3'
+
+    // then
+    XCTAssertEqual(receivedEvents1, [
+      TestReactor.Event.alertMessageDidChange("1"),
+      TestReactor.Event.countDidIncrease,
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.alertMessageDidChange("2"),
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.countDidIncrease,
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.alertMessageDidChange("3"),
+      TestReactor.Event.alertMessageDidChange("3"),
+    ])
+    XCTAssertEqual(receivedEvents2, [
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.countDidIncrease,
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.alertMessageDidChange("3"),
+      TestReactor.Event.alertMessageDidChange("3"),
+    ])
+    XCTAssertEqual(receivedEvents3, [
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.countDidIncrease,
+      TestReactor.Event.alertMessageDidClose,
+      TestReactor.Event.alertMessageDidChange("3"),
+      TestReactor.Event.alertMessageDidChange("3"),
+    ])
+    XCTAssertEqual(reactor.currentState.count, 2)
+  }
+}
+
+private final class TestReactor: Reactor {
+  enum Action {
+    case closeAlert
+    case showAlert(message: String)
+    case increaseCount
+  }
+  
+  enum Event: Equatable {
+    case alertMessageDidChange(String)
+    case alertMessageDidClose
+    case countDidIncrease
+  }
+  
+  struct State {
+    var count = 0
+  }
+
+  let initialState = State()
+
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .closeAlert:
+      return Observable.just(Event.alertMessageDidClose)
+
+    case .showAlert(let message):
+      return Observable.just(Event.alertMessageDidChange(message))
+
+    case .increaseCount:
+      return Observable.just(Event.countDidIncrease)
+    }
+  }
+
+  func reduce(state: State, event: Event) -> State {
+    var newState = state
+
+    switch event {
+    case .alertMessageDidClose:
+      // no-op
+      break
+      
+    case .alertMessageDidChange:
+      // no-op
+      break
+
+    case .countDidIncrease:
+      newState.count += 1
+    }
+
+    return newState
+  }
+}


### PR DESCRIPTION
This is a different approach to the problem that Pulse is trying to solve.
I think this approach has a logic that is simpler and clearer, making it easier for beginners to understand.
I'm finally trying a task I've been putting off for 4 years because I was too lazy. I was bored during the holiday period :)

- [ ] TODO: Modify to emit events later than state.

## Example

### Reactor

The Mutation is renamed to Event

```swift
final class TestReactor: Reactor {
  enum Action {
    case closeAlert
    case showAlert(message: String)
    case increaseCount
  }

  enum Event: Equatable {
    case alertMessageDidChange(String)
    case alertMessageDidClose
    case countDidIncrease
  }

  struct State {
    var count = 0
  }

  let initialState = State()

  func mutate(action: Action) -> Observable<Mutation> {
    switch action {
    case .closeAlert:
      return Observable.just(Event.alertMessageDidClose)

    case .showAlert(let message):
      return Observable.just(Event.alertMessageDidChange(message))

    case .increaseCount:
      return Observable.just(Event.countDidIncrease)
    }
  }

  func reduce(state: State, event: Event) -> State {
    var newState = state

    switch event {
    case .alertMessageDidClose:
      // no-op
      break

    case .alertMessageDidChange:
      // no-op
      break

    case .countDidIncrease:
      newState.count += 1
    }

    return newState
  }
}
```

### Usage of event stream

```swift
func testReceiveAllEventsCorrectly() {
  // given
  let reactor = TestReactor()
  let disposeBag = DisposeBag()
  var receivedEvents: [TestReactor.Event] = []

  reactor.event
    .subscribe(onNext: { receivedEvents.append($0) })
    .disposed(by: disposeBag)

  // when
  reactor.action.onNext(.showAlert(message: "1")) // alert '1'
  reactor.action.onNext(.increaseCount) // ignore
  reactor.action.onNext(.closeAlert) // ignore
  reactor.action.onNext(.showAlert(message: "2")) // alert '2'
  reactor.action.onNext(.closeAlert) // ignore
  reactor.action.onNext(.increaseCount) // ignore
  reactor.action.onNext(.closeAlert) // ignore
  reactor.action.onNext(.showAlert(message: "3")) // alert '3'
  reactor.action.onNext(.showAlert(message: "3")) // alert '3'

  // then
  XCTAssertEqual(receivedEvents, [
    TestReactor.Event.alertMessageDidChange("1"),
    TestReactor.Event.countDidIncrease,
    TestReactor.Event.alertMessageDidClose,
    TestReactor.Event.alertMessageDidChange("2"),
    TestReactor.Event.alertMessageDidClose,
    TestReactor.Event.countDidIncrease,
    TestReactor.Event.alertMessageDidClose,
    TestReactor.Event.alertMessageDidChange("3"),
    TestReactor.Event.alertMessageDidChange("3"),
  ])
  XCTAssertEqual(reactor.currentState.count, 2)
}
```