### PR TITLE
Add `.spi.yml` for swift package index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,7 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets:
+        - ReactorKit
+        - ReactorKitRuntime


### PR DESCRIPTION
## Background

- Add yml file to distribute docc to [swift package index](https://swiftpackageindex.com/)