### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,4 +4,3 @@ builder:
     - platform: ios
       documentation_targets:
         - ReactorKit
-        - ReactorKitRuntime


### PR DESCRIPTION
Fixes https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2977

When building docs for iOS, the list of documentation targets is given by

```
❯ xcodebuild -list -json
{
  "workspace" : {
    "name" : "ReactorKit",
    "schemes" : [
      "ReactorKit"
    ]
  }
}
```

and this doesn't include `ReactorKitRuntime` - that's they the doc generation fails!