### PR TITLE
Add documentation comment

### DIFF
--- a/Sources/ReactorKit/Pulse.swift
+++ b/Sources/ReactorKit/Pulse.swift
@@ -5,6 +5,9 @@
 //  Created by tokijh on 2021/01/11.
 //
 
+/// A property wrapper type that allows to receive events only if the new value is assigned, even if it is the same value.
+///
+/// If you want to see examples, see [Pulse](https://github.com/ReactorKit/ReactorKit?tab=readme-ov-file#pulse).
 @propertyWrapper
 public struct Pulse<Value> {
 


### PR DESCRIPTION
`Pulse` didn't have any documentation comments, even though it's a public interface. Also almost certainly need to refer to the documentation to know how to use it, so I added a summary with link to official document.