### PR TITLE
Update ActionSubject to be Simpler 

### DIFF
--- a/Tests/ReactorKitTests/ActionSubjectTests.swift
+++ b/Tests/ReactorKitTests/ActionSubjectTests.swift
@@ -5,18 +5,6 @@ import RxTest
 @testable import ReactorKit
 
 final class ActionSubjectTests: XCTestCase {
-  func testObserversCount_disposable() {
-    let subject = ActionSubject<Int>()
-    let disposable1 = subject.subscribe()
-    XCTAssertEqual(subject.observers.count, 1)
-    let disposable2 = subject.subscribe()
-    XCTAssertEqual(subject.observers.count, 2)
-    disposable2.dispose()
-    XCTAssertEqual(subject.observers.count, 1)
-    disposable1.dispose()
-    XCTAssertEqual(subject.observers.count, 0)
-  }
-
   func testEmitNexts() {
     // given
     let subject = ActionSubject<Int>()


### PR DESCRIPTION

- Refactored ActionSubject by wrapping it with PublishSubject to enhance clarity and maintainability.
- As a result, unnecessary test and execution codes could be removed, leading to a cleaner implementation.
- The refactor ensures there are no side effects or tons of break changes, preserving the original behavior of the ActionSubject. (unlike, https://github.com/ReactorKit/ReactorKit/pull/110)


++ TMI ) [RxSwift/SynchronizedOnType](https://github.com/ReactiveX/RxSwift/blob/e2b0aa8dbbafe1552d3cfbc9b8c8087615762f0c/RxSwift/Concurrency/SynchronizedOnType.swift) i want use this for locking. but it was internal type. 🫠