### PR TITLE
Add: Adding throttle to the counter example

### DIFF
--- a/Examples/Counter/Counter/CounterViewController.swift
+++ b/Examples/Counter/Counter/CounterViewController.swift
@@ -23,12 +23,22 @@ final class CounterViewController: UIViewController, StoryboardView {
   // Called when the new value is assigned to `self.reactor`
   func bind(reactor: CounterViewReactor) {
     // Action
-    increaseButton.rx.tap               // Tap event
+    increaseButton.rx.tap // Tap event
+      .throttle(
+        .milliseconds(500),
+        latest: false,
+        scheduler: MainScheduler.instance
+      )
       .map { Reactor.Action.increase }  // Convert to Action.increase
       .bind(to: reactor.action)         // Bind to reactor.action
       .disposed(by: disposeBag)
 
     decreaseButton.rx.tap
+      .throttle(
+        .milliseconds(500),
+        latest: false,
+        scheduler: MainScheduler.instance
+      )
       .map { Reactor.Action.decrease }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)


### PR DESCRIPTION
The number was incremented or decremented multiple times with successive button clicks.
Added throttle to prevent continuous event emission during timer.

https://github.com/ReactorKit/ReactorKit/assets/91649269/276d5d53-b715-4dd2-a110-c634dfa520a2

