### PR TITLE
Refactor projectedValue to use Self as the return type

### DIFF
--- a/Sources/ReactorKit/Pulse.swift
+++ b/Sources/ReactorKit/Pulse.swift
@@ -28,7 +28,7 @@ public struct Pulse<Value> {
     set { value = newValue }
   }
 
-  public var projectedValue: Pulse<Value> {
+  public var projectedValue: Self {
     self
   }
 


### PR DESCRIPTION
- Changed the projectedValue return type from Pulse<Value> to Self
- Improves code flexibility and maintainability