### PR TITLE
Prepare for Swift 6: remove obsolete typealiases and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,8 @@ jobs:
       matrix:
         env:
           - sdk: iphonesimulator
-            destination: platform=iOS Simulator,name=iPhone 14 Pro,OS=latest
-
           - sdk: macosx
-            destination: arch=x86_64
-
           - sdk: appletvsimulator
-            destination: platform=tvOS Simulator,name=Apple TV,OS=latest
 
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +28,22 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest
+
+      - name: Select iOS Simulator dynamically
+        if: matrix.env.sdk == 'iphonesimulator'
+        run: |
+          OS_VERSION=$(xcrun simctl list runtimes | grep 'iOS' | grep -oE '[0-9]+\.[0-9]+' | sort -Vr | head -n1)
+          DEVICE_NAME=$(xcrun simctl list devices | grep -A 20 "^-- iOS $OS_VERSION --" | grep -E '^ *iPhone [0-9]+ \(' | grep -v 'Pro\|Plus\|SE\|unavailable' | sed -E 's/^[[:space:]]*([^()]+) \(.*/\1/' | sort -t' ' -k2 -n -r | head -n1)
+          echo "Using simulator: $DEVICE_NAME (iOS $OS_VERSION)"
+          echo "DESTINATION=platform=iOS Simulator,name=$DEVICE_NAME,OS=$OS_VERSION" >> $GITHUB_ENV
+
+      - name: Set macOS destination
+        if: matrix.env.sdk == 'macosx'
+        run: echo "DESTINATION=arch=x86_64" >> $GITHUB_ENV
+
+      - name: Set tvOS destination
+        if: matrix.env.sdk == 'appletvsimulator'
+        run: echo "DESTINATION=platform=tvOS Simulator,name=Apple TV,OS=latest" >> $GITHUB_ENV
 
       - name: Build and Test
         run: |
@@ -46,7 +57,7 @@ jobs:
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c;
         env:
           SDK: ${{ matrix.env.sdk }}
-          DESTINATION: ${{ matrix.env.destination }}
+          DESTINATION: ${{ env.DESTINATION }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.0

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -9,12 +9,6 @@
 import RxSwift
 import WeakMapTable
 
-@available(*, obsoleted: 0, renamed: "Never")
-public typealias NoAction = Never
-
-@available(*, obsoleted: 0, renamed: "Never")
-public typealias NoMutation = Never
-
 /// A Reactor is an UI-independent layer which manages the state of a view. The foremost role of a
 /// reactor is to separate control flow from a view. Every view has its corresponding reactor and
 /// delegates all logic to its reactor. A reactor has no dependency to a view, so it can be easily

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -29,8 +29,6 @@ public protocol Reactor: AnyObject {
   /// A State represents the current state of a view.
   associatedtype State
 
-  typealias Scheduler = ImmediateSchedulerType
-
   /// The action from the view. Bind user inputs to this subject.
   var action: ActionSubject<Action> { get }
 


### PR DESCRIPTION
This PR cleans up unused and obsolete typealiases and improves CI stability in preparation for Swift 6:

- Removes the `Scheduler` typealias, which was defined but never used. This was likely missed in #218.
- Removes `NoAction` and `NoMutation` typealiases that were previously marked as `@available(*, obsoleted: 0, renamed: "Never")`. These were already unusable and now cause a compiler error in Swift 6.
- Updates the GitHub Actions CI script to dynamically select the latest available iOS Simulator. This avoids hardcoding device names and improves CI robustness.

These changes are safe to land and help clean up compatibility issues ahead of Swift 6 adoption.