### PR TITLE
Add `run` for Swift Concurrency in Reactor

### DIFF
--- a/Examples/Counter/Counter/CounterViewReactor.swift
+++ b/Examples/Counter/Counter/CounterViewReactor.swift
@@ -52,6 +52,15 @@ final class CounterViewReactor: Reactor {
       ])
 
     case .decrease:
+      if #available(iOS 13.0, *) {
+        return run { send in
+          send(.setLoading(true))
+          try? await Task.sleep(nanoseconds: 500 * 1_000_000)
+          send(.decreaseValue)
+          send(.setLoading(false))
+          send(.setAlertMessage("decreased!"))
+        }
+      }
       return Observable.concat([
         Observable.just(Mutation.setLoading(true)),
         Observable.just(Mutation.decreaseValue).delay(.milliseconds(500), scheduler: MainScheduler.instance),

--- a/Sources/ReactorKit/Reactor+Run.swift
+++ b/Sources/ReactorKit/Reactor+Run.swift
@@ -1,0 +1,81 @@
+//
+//  Reactor+Run.swift
+//  Pods
+//
+//  Created by 이병찬 on 9/3/25.
+//
+
+import RxSwift
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+public extension Reactor {
+
+    /// Provides support for Swift Concurrency (inspired by The Composable Architecture).
+    /// https://github.com/pointfreeco/swift-composable-architecture/blob/acd9bb8a7cf6e36a89d81a432c2e8eb3b1bb3771/Sources/ComposableArchitecture/Effect.swift#L87-L95
+    ///
+    /// This method bridges Swift Concurrency (`Task`) with ReactorKit's `Mutation` stream.
+    /// Inside the `operation` closure, you can call `send(_:)` to emit mutations.
+    /// Once the task finishes, the observable automatically sends `onCompleted()`.
+    ///
+    /// > Important: Both the execution of the `operation` closure and the emissions
+    /// > from the returned `Observable<Mutation>` are guaranteed to occur on the **main thread**.
+    /// > The `scheduler` parameter determines the thread for emissions, and by default,
+    /// > `scheduler: ImmediateSchedulerType = MainScheduler.instance` ensures main-thread execution.
+    ///
+    /// ## Example
+    /// ```swift
+    /// func mutateA() -> Observable<Mutation> {
+    ///     return run { send in
+    ///         for await event in self.events() {
+    ///             send(Mutation.event(event))
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - priority: The priority of the created `Task`. Default is `nil`,
+    ///               meaning the system decides the priority automatically.
+    ///   - scheduler: The Rx scheduler on which `operation` executes and the returned
+    ///                `Observable` emits. Default is `MainScheduler.instance`.
+    ///   - operation: A Swift Concurrency closure where mutations can be emitted
+    ///                via the `Send<Mutation>` parameter. Executed on the provided scheduler.
+    ///
+    /// - Returns: An `Observable<Mutation>` that emits values sent during the Swift Concurrency operation,
+    ///            on the provided scheduler (default: main thread).
+    ///
+    func run(
+        priority: TaskPriority? = nil,
+        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        operation: @escaping @MainActor @Sendable (_ send: Send<Mutation>) async -> Void,
+    ) -> Observable<Mutation> {
+        .create { observer in
+            let task = Task(priority: priority) {
+                let send = Send { observer.onNext($0) }
+                await operation(send)
+                observer.onCompleted()
+            }
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+        .observe(on: scheduler)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+/// A helper type for emitting `Mutation`s inside a Swift Concurrency task.
+/// unless the task has been cancelled.
+public struct Send<Mutation>: Sendable {
+
+    let send: @Sendable (Mutation) -> Void
+
+    public init(_ send: @escaping @Sendable (Mutation) -> Void) {
+        self.send = send
+    }
+
+    public func callAsFunction(_ mutation: Mutation) {
+        guard !Task.isCancelled else { return }
+        self.send(mutation)
+    }
+}

--- a/Tests/ReactorKitTests/Reactor+RunTests.swift
+++ b/Tests/ReactorKitTests/Reactor+RunTests.swift
@@ -1,0 +1,82 @@
+//
+//  Reactor+RunTests.swift
+//  ReactorKit
+//
+//  Created by 이병찬 on 9/3/25.
+//
+
+import XCTest
+import RxSwift
+
+@testable import ReactorKit
+
+final class Reactor_RunTests: XCTestCase {
+
+    @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+    func testRunSimple() async {
+        // Given
+        let expectedCounts = [1, 2, 3, 4].shuffled()
+        var recodedCounts: [Int] = []
+        let reactor = TestReactor()
+        let disposeBag = DisposeBag()
+
+        // When
+        reactor.state.compactMap(\.count)
+            .subscribe(onNext: { count in
+                recodedCounts.append(count)
+            })
+            .disposed(by: disposeBag)
+
+        let stream = AsyncStream<Int> { continuation in
+            for value in expectedCounts {
+                continuation.yield(value)
+            }
+            continuation.finish()
+        }
+        reactor.action.onNext(.refreshCount(stream))
+
+        // Then (just waiting 1 miliseonds for execution stream.)
+        try? await Task.sleep(nanoseconds: 1_000_000)
+        XCTAssertEqual(expectedCounts, recodedCounts)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+private final class TestReactor: Reactor {
+
+    enum Action {
+        case refreshCount(AsyncStream<Int>)
+    }
+
+    enum Mutation {
+        case setCount(Int)
+    }
+
+    struct State {
+        var count: Int?
+    }
+
+    let initialState = State()
+
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .refreshCount(let stream):
+            run(scheduler: CurrentThreadScheduler.instance) { send in
+                for await count in stream {
+                    send(.setCount(count))
+                }
+            }
+        }
+    }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+
+        switch mutation {
+        case .setCount(let count):
+            newState.count = count
+        }
+
+        return newState
+    }
+}


### PR DESCRIPTION
### Summary
- Add new helper func `run` in Reactor, allowing Swift Concurrency tasks to emit `Mutation` events through an `Observable`.
- The helper `Send` struct is added to safely forward mutations from within a Swift Concurrency task.
- The implementation is inspired by patterns from [The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture/blob/acd9bb8a7cf6e36a89d81a432c2e8eb3b1bb3771/Sources/ComposableArchitecture/Effect.swift#L87-L95).

### Usage Example
```swift
func mutate(action: Action) -> Observable<Mutation> {
    switch action {
    case .loadData:
        return run { send in
            do {
                let data = try await api.fetchData()
                send(.setData(data))
            } catch {
                send(.setError(error))
            }
        }
    }
}
```