### PR TITLE
Rename View protocols for clarity and SwiftUI compatibility

### DIFF
--- a/Examples/Counter/Counter/CounterViewController.swift
+++ b/Examples/Counter/Counter/CounterViewController.swift
@@ -13,7 +13,7 @@ import RxCocoa
 import RxSwift
 
 // Conform to the protocol `View` then the property `self.reactor` will be available.
-final class CounterViewController: UIViewController, StoryboardView {
+final class CounterViewController: UIViewController, DeferredReactorView {
   @IBOutlet var decreaseButton: UIButton!
   @IBOutlet var increaseButton: UIButton!
   @IBOutlet var valueLabel: UILabel!

--- a/Examples/GitHubSearch/GitHubSearch/GitHubSearchViewController.swift
+++ b/Examples/GitHubSearch/GitHubSearch/GitHubSearchViewController.swift
@@ -13,7 +13,7 @@ import ReactorKit
 import RxCocoa
 import RxSwift
 
-class GitHubSearchViewController: UIViewController, StoryboardView {
+class GitHubSearchViewController: UIViewController, DeferredReactorView {
   @IBOutlet var tableView: UITableView!
   let searchController = UISearchController(searchResultsController: nil)
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ ReactorKit is a combination of [Flux](https://facebook.github.io/flux/) and [Rea
 
 A _View_ displays data. A view controller and a cell are treated as a view. The view binds user inputs to the action stream and binds the view states to each UI component. There's no business logic in a view layer. A view just defines how to map the action stream and the state stream.
 
-To define a view, just have an existing class conform a protocol named `View`. Then your class will have a property named `reactor` automatically. This property is typically set outside of the view.
+To define a view, just have an existing class conform a protocol named `ReactorView`. Then your class will have a property named `reactor` automatically. This property is typically set outside of the view.
 
 ```swift
-class ProfileViewController: UIViewController, View {
+class ProfileViewController: UIViewController, ReactorView {
   var disposeBag = DisposeBag()
 }
 
@@ -97,13 +97,13 @@ func bind(reactor: ProfileViewReactor) {
 
 #### Storyboard Support
 
-Use `StoryboardView` protocol if you're using a storyboard to initialize view controllers. Everything is same but the only difference is that the `StoryboardView` performs a binding after the view is loaded.
+Use `DeferredReactorView` protocol if you're using a storyboard to initialize view controllers. Everything is same but the only difference is that the `DeferredReactorView` defers binding until the view is loaded.
 
 ```swift
 let viewController = MyViewController()
-viewController.reactor = MyViewReactor() // will not executes `bind(reactor:)` immediately
+viewController.reactor = MyViewReactor() // will not execute `bind(reactor:)` immediately
 
-class MyViewController: UIViewController, StoryboardView {
+class MyViewController: UIViewController, DeferredReactorView {
   func bind(reactor: MyViewReactor) {
     // this is called after the view is loaded (viewDidLoad)
   }

--- a/Sources/ReactorKit/DeferredReactorView.swift
+++ b/Sources/ReactorKit/DeferredReactorView.swift
@@ -17,13 +17,13 @@ private enum MapTables {
   static let isReactorBinded = WeakMapTable<AnyView, Bool>()
 }
 
-public protocol _ObjCStoryboardView {
+public protocol _ObjCDeferredReactorView {
   func performBinding()
 }
 
-public protocol StoryboardView: View, _ObjCStoryboardView {}
+public protocol DeferredReactorView: ReactorView, _ObjCDeferredReactorView {}
 
-extension StoryboardView {
+extension DeferredReactorView {
   public var reactor: Reactor? {
     get { MapTables.reactor.value(forKey: self) as? Reactor }
     set {
@@ -60,7 +60,7 @@ extension StoryboardView {
 extension OSViewController {
   @objc
   func _reactorkit_performBinding() {
-    (self as? _ObjCStoryboardView)?.performBinding()
+    (self as? _ObjCDeferredReactorView)?.performBinding()
   }
 }
 #endif

--- a/Sources/ReactorKit/ReactorView.swift
+++ b/Sources/ReactorKit/ReactorView.swift
@@ -1,5 +1,5 @@
 //
-//  View.swift
+//  ReactorView.swift
 //  ReactorKit
 //
 //  Created by Suyeol Jeon on 13/04/2017.
@@ -18,7 +18,7 @@ private enum MapTables {
 /// A View displays data. A view controller and a cell are treated as a view. The view binds user
 /// inputs to the action stream and binds the view states to each UI component. There's no business
 /// logic in a view layer. A view just defines how to map the action stream and the state stream.
-public protocol View: AnyObject {
+public protocol ReactorView: AnyObject {
   associatedtype Reactor: ReactorKit.Reactor
 
   /// A dispose bag. It is disposed each time the `reactor` is assigned.
@@ -51,7 +51,7 @@ public protocol View: AnyObject {
 
 // MARK: - Default Implementations
 
-extension View {
+extension ReactorView {
   public var reactor: Reactor? {
     get { MapTables.reactor.value(forKey: self) as? Reactor }
     set {

--- a/Tests/ReactorKitTests/ReactorViewTests.swift
+++ b/Tests/ReactorKitTests/ReactorViewTests.swift
@@ -14,7 +14,7 @@ private typealias OSView = NSView
 #endif
 
 #if !os(Linux)
-final class ViewTests: XCTestCase {
+final class ReactorViewTests: XCTestCase {
   func testBindIsInvoked_differentReactor() {
     let view = TestView()
     XCTAssertEqual(view.bindInvokeCount, 0)
@@ -100,7 +100,7 @@ final class ViewTests: XCTestCase {
   }
 }
 
-private final class TestView: View {
+private final class TestView: ReactorView {
   var disposeBag = DisposeBag()
   var bindInvokeCount = 0
 
@@ -109,7 +109,7 @@ private final class TestView: View {
   }
 }
 
-private final class TestViewController: OSViewController, StoryboardView {
+private final class TestViewController: OSViewController, DeferredReactorView {
   var disposeBag = DisposeBag()
   var isLoadViewInvoked = false
   var bindInvokeCount = 0


### PR DESCRIPTION
## Summary

This PR renames the core view protocols to better describe their purpose and avoid naming conflicts with SwiftUI.

### Changes

**BREAKING CHANGE**: Protocol names have been updated:
- `View` → `ReactorView` (avoids conflict with SwiftUI.View)
- `StoryboardView` → `DeferredReactorView` (better describes deferred binding behavior)
- Internal `_ObjCStoryboardView` → `_ObjCDeferredReactorView`

### Rationale

1. **`View` → `ReactorView`**
   - The generic name `View` conflicts with `SwiftUI.View`, causing signature ambiguity
   - `ReactorView` clearly indicates this is ReactorKit's view protocol
   - Follows common patterns in architectural frameworks (e.g., MVVM's `ViewModel`)

2. **`StoryboardView` → `DeferredReactorView`**
   - The name "StoryboardView" is misleading - it's not limited to storyboards
   - The protocol's actual purpose is to defer binding until the view is loaded (`isViewLoaded == false`)
   - Works with both storyboard and programmatically created view controllers
   - `DeferredReactorView` accurately describes the deferred binding behavior

### Files Renamed
- `View.swift` → `ReactorView.swift`
- `StoryboardView.swift` → `DeferredReactorView.swift`
- `ViewTests.swift` → `ReactorViewTests.swift`

### Migration Guide

For users upgrading to this version:

```swift
// Before
class MyViewController: UIViewController, View {
  // ...
}

class MyStoryboardViewController: UIViewController, StoryboardView {
  // ...
}

// After
class MyViewController: UIViewController, ReactorView {
  // ...
}

class MyStoryboardViewController: UIViewController, DeferredReactorView {
  // ...
}
```

## Test Plan

- [x] All existing tests pass
- [x] Test class renamed to `ReactorViewTests`
- [x] Documentation updated in README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed public protocols: View → ReactorView and StoryboardView → DeferredReactorView; updated bridge protocol name and related bindings.

* **Documentation**
  * Updated examples and guidance to use ReactorView and DeferredReactorView.
  * Clarified wording about deferred binding behavior.

* **Tests**
  * Updated test names and conformances to match ReactorView and DeferredReactorView.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->