### PR TITLE
chore: remove GitBook integration

### DIFF
--- a/.gitbook.yml
+++ b/.gitbook.yml
@@ -1,5 +1,0 @@
-root: ./
-
-structure:
-  readme: README.md
-  summary: Documentation/README.md


### PR DESCRIPTION
## Summary

Remove `.gitbook.yml` config file. Documentation is no longer served through GitBook.

## Changes

- Delete `.gitbook.yml` that configured GitBook to use `README.md` as root and `Documentation/README.md` as summary.
- `Documentation/` directory is unaffected — it contains project docs independent of GitBook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation configuration by simplifying settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->