### PR TITLE
feat: restore scheduler with MainScheduler default

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,31 @@ func testIsLoading() {
 }
 ```
 
+### Scheduling
+
+Override the `scheduler` property to specify which scheduler runs reduction and state delivery. The default is `MainScheduler.instance`, which makes state subscription safe to bind directly to UI without an additional `observe(on:)` hop.
+
+The scheduler is applied at the **effect boundary** — each `mutate(_:)` output is rescheduled through `scheduler` before reaching `transform(mutation:)`, `reduce(_:_:)`, `transform(state:)`, and state subscribers. This holds even when `mutate(_:)` returns an observable that emits on a background thread (e.g. a network response), so you do not need to add `.observe(on: MainScheduler.instance)` inside every async `mutate` return.
+
+Override with a serial scheduler when you need to move heavy reduction work off the main thread:
+
+```swift
+final class MyReactor: Reactor {
+  let scheduler: Scheduler = SerialDispatchQueueScheduler(qos: .default)
+
+  func reduce(state: State, mutation: Mutation) -> State {
+    // executed on the background serial queue
+    heavyAndImportantCalculation()
+    return state
+  }
+}
+```
+
+Notes:
+- The scheduler **must be serial**. Concurrent schedulers break the "single writer" invariant the reducer relies on.
+- `transform(action:)` runs on the action's emission thread, not `scheduler`. Downstream of `mutate(_:)` is the scheduled section.
+- When using `ObservedReactor` for SwiftUI, keep the default `MainScheduler.instance`. Overriding to a non-main scheduler violates `ObservedReactor`'s main-actor contract.
+
 ### Pulse
 
 `Pulse` has diff only when mutated

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -23,6 +23,8 @@ public protocol Reactor: AnyObject {
   /// A State represents the current state of a view.
   associatedtype State
 
+  typealias Scheduler = ImmediateSchedulerType
+
   /// The action from the view. Bind user inputs to this subject.
   var action: ActionSubject<Action> { get }
 
@@ -34,6 +36,19 @@ public protocol Reactor: AnyObject {
 
   /// The state stream. Use this observable to observe the state changes.
   var state: Observable<State> { get }
+
+  /// A scheduler for reducing and observing the state stream. Defaults to `MainScheduler.instance`.
+  ///
+  /// Applied at the effect boundary — each `mutate(_:)` output is rescheduled
+  /// through this scheduler before reaching `transform(mutation:)`, `reduce(_:_:)`,
+  /// `transform(state:)`, and state subscribers. This guarantees reduce and state
+  /// delivery happen on the scheduler even when `mutate(_:)` returns an observable
+  /// that emits on a background thread (e.g. a network response).
+  ///
+  /// `transform(action:)` runs on the action's emission thread, not this
+  /// scheduler. Override with a serial scheduler (e.g. `SerialDispatchQueueScheduler`)
+  /// to move reduction off the main thread.
+  var scheduler: Scheduler { get }
 
   /// Transforms the action. Use this function to combine with other observables. This method is
   /// called once before the state stream is created.
@@ -102,6 +117,10 @@ extension Reactor {
     streams.state
   }
 
+  public var scheduler: Scheduler {
+    MainScheduler.instance
+  }
+
   fileprivate var disposeBag: DisposeBag {
     MapTables.disposeBag.value(forKey: self, default: DisposeBag())
   }
@@ -113,7 +132,9 @@ extension Reactor {
     let mutation = transformedAction
       .flatMap { [weak self] action -> Observable<Mutation> in
         guard let self = self else { return .empty() }
-        return self.mutate(action: action).catch { _ in .empty() }
+        return self.mutate(action: action)
+          .catch { _ in .empty() }
+          .observe(on: self.scheduler)
       }
     let transformedMutation = transform(mutation: mutation)
     let state = transformedMutation

--- a/Sources/ReactorKitSwiftUI/ObservedReactor.swift
+++ b/Sources/ReactorKitSwiftUI/ObservedReactor.swift
@@ -142,11 +142,15 @@ public final class ObservedReactor<R: Reactor> where R.State: ObservableState {
   /// Creates an observed reactor, subscribing to the reactor's state
   /// stream and routing every emission through the `state` setter so
   /// observation notifications fire on the main actor.
+  ///
+  /// Contract: `R.scheduler` must be main-thread-isolated (the default
+  /// `MainScheduler.instance` satisfies this). Overriding it to a
+  /// background scheduler while using `ObservedReactor` violates the
+  /// `@MainActor` contract and will trap in `assumeIsolated` below.
   public init(reactor: R) {
     self.reactor = reactor
     self._state = reactor.initialState
     reactor.state
-      .observe(on: MainScheduler.instance)
       .subscribe(onNext: { [weak self] state in
         MainActor.assumeIsolated {
           self?.state = state
@@ -249,7 +253,6 @@ extension ObservedReactor {
     _ transformToPulse: @escaping @Sendable (R.State) throws -> Pulse<Value>
   ) -> AsyncStream<Value> {
     let observable = reactor.pulse(transformToPulse)
-      .observe(on: MainScheduler.instance)
     return AsyncStream { continuation in
       let disposable = observable
         .subscribe(

--- a/Tests/ReactorKitTests/ReactorSchedulerTests.swift
+++ b/Tests/ReactorKitTests/ReactorSchedulerTests.swift
@@ -56,4 +56,119 @@ final class ReactorSchedulerTests: XCTestCase {
       XCTAssertTrue(state === states.value.first)
     }
   }
+
+  func testDefaultScheduler() {
+    final class SimpleReactor: Reactor, @unchecked Sendable {
+      typealias Action = Void
+      typealias Mutation = Void
+
+      struct State {
+        var reductionThreads: [Thread] = []
+      }
+
+      let initialState = State()
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        newState.reductionThreads.append(Thread.current)
+        return newState
+      }
+    }
+
+    final class ThreadBox: @unchecked Sendable {
+      var observationThreads: [Thread] = []
+    }
+
+    let reactor = SimpleReactor()
+    let disposeBag = DisposeBag()
+    let threads = ThreadBox()
+    let expectation = XCTestExpectation()
+
+    DispatchQueue.global().async {
+      reactor.state
+        .subscribe(onNext: { _ in
+          threads.observationThreads.append(Thread.current)
+          if threads.observationThreads.count == 101 { // +1 for initial state
+            expectation.fulfill()
+          }
+        })
+        .disposed(by: disposeBag)
+
+      for _ in 0..<100 {
+        reactor.action.onNext(Void())
+      }
+    }
+
+    XCTWaiter().wait(for: [expectation], timeout: 5)
+
+    let reductionThreads = reactor.currentState.reductionThreads
+    XCTAssertEqual(reductionThreads.count, 100)
+    // Default scheduler is MainScheduler — reduce runs on main.
+    for thread in reductionThreads {
+      XCTAssertTrue(thread.isMainThread)
+    }
+    // Post-initial emissions are rescheduled to main via the upstream observe(on:).
+    // The initial-state emission (index 0) is delivered on the subscribe thread.
+    XCTAssertEqual(threads.observationThreads.count, 101)
+    for thread in threads.observationThreads.dropFirst() {
+      XCTAssertTrue(thread.isMainThread)
+    }
+  }
+
+  func testCustomScheduler() {
+    final class SimpleReactor: Reactor, @unchecked Sendable {
+      typealias Action = Void
+      typealias Mutation = Void
+
+      struct State {
+        var reductionThreads: [Thread] = []
+      }
+
+      let initialState = State()
+      let scheduler: ImmediateSchedulerType = SerialDispatchQueueScheduler(qos: .default)
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        newState.reductionThreads.append(Thread.current)
+        return newState
+      }
+    }
+
+    final class ThreadBox: @unchecked Sendable {
+      var observationThreads: [Thread] = []
+    }
+
+    let reactor = SimpleReactor()
+    let disposeBag = DisposeBag()
+    let threads = ThreadBox()
+    let expectation = XCTestExpectation()
+
+    DispatchQueue.global().async {
+      reactor.state
+        .subscribe(onNext: { _ in
+          threads.observationThreads.append(Thread.current)
+          if threads.observationThreads.count == 101 {
+            expectation.fulfill()
+          }
+        })
+        .disposed(by: disposeBag)
+
+      for _ in 0..<100 {
+        reactor.action.onNext(Void())
+      }
+    }
+
+    XCTWaiter().wait(for: [expectation], timeout: 5)
+
+    let reductionThreads = reactor.currentState.reductionThreads
+    XCTAssertEqual(reductionThreads.count, 100)
+    // Custom scheduler is a background serial queue — reduce runs off main.
+    for thread in reductionThreads {
+      XCTAssertFalse(thread.isMainThread)
+    }
+    XCTAssertEqual(threads.observationThreads.count, 101)
+    for thread in threads.observationThreads.dropFirst() {
+      XCTAssertFalse(thread.isMainThread)
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Re-add `Reactor.scheduler` property (removed in #218) with `MainScheduler.instance` default
- Apply scheduler at the **effect boundary** — each `mutate(_:)` output is rescheduled through `scheduler` before `transform(mutation:)`, `reduce`, `transform(state:)`, and subscribers
- Drop redundant `observe(on: MainScheduler.instance)` from `ObservedReactor.init` and `pulse()` — with core now guaranteeing main delivery, the extra hop was redundant and (via chained `MainScheduler`) broke the sync optimistic-binding contract

## Why

PR #218 removed `Reactor.scheduler` and pushed threading responsibility onto users. The SwiftUI integration in #252 makes this too loose:

- `ObservedReactor` uses `MainActor.assumeIsolated` — any off-main state emission traps at runtime
- Without a library-guaranteed scheduler, async `mutate` (e.g. network responses on URLSession's queue) silently escapes main, and the user is expected to add `observe(on: MainScheduler.instance)` inside every async mutate

## Design: effect-boundary placement

```swift
let mutation = transformedAction
  .flatMap { [weak self] action in
    self.mutate(action: action).catch { _ in .empty() }
      .observe(on: self.scheduler)
  }
```

Compared to alternatives:

| Placement | Sync mutate | Async mutate |
| --- | --- | --- |
| Action upstream (2019 `dc8f2fe`) | reduce/state on scheduler | reduce/state escape to mutate's thread |
| State downstream (2022 `180bd2a`) | subscribers on scheduler | `currentState` setter on mutate's thread |
| **Effect boundary (this PR, pre-2019 original)** | reduce/state on scheduler | **reduce/state on scheduler** |

`dc8f2fe`'s stated goal ("mutate and reduce on the same serial scheduler") is only actually satisfied by the effect-boundary variant — action-upstream just moves the subscription point, not the emission point.

## Caveats

- `transform(action:)` now runs on the action's emission thread, not `scheduler`. Reactors that relied on scheduled side-effects inside `transform(action:)` must move them into `mutate` or add `observe(on:)` explicitly. Most code does not rely on this.
- `observe(on:)` is per-effect (inside `flatMap`) rather than once upstream — negligible on `MainScheduler`; worth noting on hot loops with a custom scheduler.
- When using `ObservedReactor` for SwiftUI, keep `scheduler = MainScheduler.instance`. Overriding to a background scheduler violates the `@MainActor` contract and will trap in `assumeIsolated`.

## Test plan

- [x] 143 tests pass, including restored `testDefaultScheduler` / `testCustomScheduler`
- [x] `testReducerTransformIsAppliedSynchronously` (the SwiftUI sync optimistic-binding contract) still passes — dropping the redundant `observe(on:)` in `ObservedReactor` was required for it to pass under this placement
- [ ] Manual: exercise async `mutate` (e.g. network call emitting on background) against `ObservedReactor` — confirm no `assumeIsolated` trap and reduce runs on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a `scheduler` property that controls when reduction and state delivery occur, with a default main-thread scheduler for backward compatibility.
  * Custom serial schedulers can be configured for specialized threading control during state mutations and updates.

* **Documentation**
  * Added "Scheduling" section explaining scheduler behavior and configuration guidelines.

* **Tests**
  * Added scheduler tests validating default and custom scheduler thread behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->