### PR TITLE
chore: replace master references with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 concurrency:

--- a/Documentation/Contents/Pulse.md
+++ b/Documentation/Contents/Pulse.md
@@ -186,7 +186,7 @@ The official document of ReactorKit provides additional explanations and example
 
 The most important part is `if the new value is assigned`. That is, the stream does not emit events unless a new value is assigned.
 
-Let's look at an additional [example](https://github.com/ReactorKit/ReactorKit/blob/master/Tests/ReactorKitTests/PulseTests.swift).
+Let's look at an additional [example](https://github.com/ReactorKit/ReactorKit/blob/main/Tests/ReactorKitTests/PulseTests.swift).
 
 ```swift
 import XCTest

--- a/Documentation/Tutorials/GitHubSearch/README.md
+++ b/Documentation/Tutorials/GitHubSearch/README.md
@@ -1,3 +1,3 @@
 # GitHub Search
 
-In this tutorial we'll make a simplified version of [GitHubSearch example](https://github.com/ReactorKit/ReactorKit/tree/master/Examples/GitHubSearch). You can learn how to implement the basic `View` and `Reactor`. This tutorial is for beginners so it doesn't contain advance usage. Check [Examples](https://github.com/ReactorKit/ReactorKit#examples) section on README for more examples.
+In this tutorial we'll make a simplified version of [GitHubSearch example](https://github.com/ReactorKit/ReactorKit/tree/main/Examples/GitHubSearch). You can learn how to implement the basic `View` and `Reactor`. This tutorial is for beginners so it doesn't contain advance usage. Check [Examples](https://github.com/ReactorKit/ReactorKit#examples) section on README for more examples.

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ oldMessagePulse.value == messagePulse.value // true
 ```
 
 Use when you want to receive an event only if the new value is assigned, even if it is the same value.
-like `alertMessage` (See follows or [PulseTests.swift](https://github.com/ReactorKit/ReactorKit/blob/master/Tests/ReactorKitTests/PulseTests.swift))
+like `alertMessage` (See follows or [PulseTests.swift](https://github.com/ReactorKit/ReactorKit/blob/main/Tests/ReactorKitTests/PulseTests.swift))
 
 ```swift
 // Reactor
@@ -632,9 +632,9 @@ SwiftUI support requires Swift Package Manager (CocoaPods is not supported due t
 
 ## Examples
 
-- [Counter](https://github.com/ReactorKit/ReactorKit/tree/master/Examples/Counter): The most simple and basic example of ReactorKit (UIKit)
-- [SwiftUI Counter](https://github.com/ReactorKit/ReactorKit/tree/master/Examples/SwiftUICounter): A SwiftUI example using ObservedReactor and ReactorObserving
-- [GitHub Search](https://github.com/ReactorKit/ReactorKit/tree/master/Examples/GitHubSearch): A simple application which provides a GitHub repository search
+- [Counter](https://github.com/ReactorKit/ReactorKit/tree/main/Examples/Counter): The most simple and basic example of ReactorKit (UIKit)
+- [SwiftUI Counter](https://github.com/ReactorKit/ReactorKit/tree/main/Examples/SwiftUICounter): A SwiftUI example using ObservedReactor and ReactorObserving
+- [GitHub Search](https://github.com/ReactorKit/ReactorKit/tree/main/Examples/GitHubSearch): A simple application which provides a GitHub repository search
 - [RxTodo](https://github.com/devxoul/RxTodo): iOS Todo Application using ReactorKit
 - [Cleverbot](https://github.com/devxoul/Cleverbot): iOS Messaging Application using Cleverbot and ReactorKit
 - [Drrrible](https://github.com/devxoul/Drrrible): Dribbble for iOS using ReactorKit ([App Store](https://itunes.apple.com/us/app/drrrible/id1229592223?mt=8))
@@ -754,4 +754,4 @@ Any discussions and pull requests are welcomed 💖
 
 ## License
 
-ReactorKit is under MIT license. See the [LICENSE](https://github.com/ReactorKit/ReactorKit/blob/master/LICENSE) for more info.
+ReactorKit is under MIT license. See the [LICENSE](https://github.com/ReactorKit/ReactorKit/blob/main/LICENSE) for more info.

--- a/Sources/ReactorKit/Reactor+Pulse.swift
+++ b/Sources/ReactorKit/Reactor+Pulse.swift
@@ -8,7 +8,7 @@
 extension Reactor {
   /// Returns an observable sequence that emits the value of the pulse only when its valueUpdatedCount changes.
   ///
-  /// - seealso: [Pulse document](https://github.com/ReactorKit/ReactorKit/blob/master/Documentation/Contents/Pulse.md)
+  /// - seealso: [Pulse document](https://github.com/ReactorKit/ReactorKit/blob/main/Documentation/Contents/Pulse.md)
   /// - seealso: [The official document introduction](https://github.com/ReactorKit/ReactorKit#pulse)
   ///
   /// - parameter transformToPulse: A transform function to apply to the current state of the reactor


### PR DESCRIPTION
## Summary

Follow-up to renaming the default branch from `master` to `main`. Sweeps the repository for remaining `master` references and updates only the ones that point at this repository.

## Changes

- `.github/workflows/ci.yml`: `push` trigger now fires on `main` (was `master`, which no longer exists).
- `README.md`, `Documentation/**`, `Sources/ReactorKit/Reactor+Pulse.swift`: self-referencing GitHub links (`blob/` / `tree/` paths) updated to `main`. GitHub redirects the old URLs for now, but updating removes the dependency on that redirect.

## Intentionally left alone

External links to repositories owned by others — they manage their own default branch:
- `ReactiveX/RxSwift/blob/master/RxSwift/Reactive.swift` (README.md:246)
- `apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md` (Documentation/Contents/Pulse.md:123)

## Test plan

- [x] `grep -r master` shows only the two external links above
- [x] After merge: CI workflow runs on the next `main` push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to trigger on the `main` branch.
  * Updated documentation and reference links throughout the project to point to the `main` branch instead of `master`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->