### PR TITLE
refactor(swiftui): drop pulse(_:) from ObservedReactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ You may want to see the [Examples](#examples) section first if you'd like to see
   - [ObservableState](#observablestate)
   - [ObservedReactor](#observedreactor)
   - [ReactorObserving](#reactorobserving)
-  - [Pulse in SwiftUI](#pulse-in-swiftui)
   - [Bindings](#bindings)
     - [@ReactorBindable](#reactorbindable)
     - [binding(get:send:)](#bindinggetsend)
@@ -518,24 +517,6 @@ struct ProfileView: View {
   var body: some View {
     Text(reactor.username)
     Button("Follow") { reactor.send(.follow) }
-  }
-}
-```
-
-### Pulse in SwiftUI
-
-Use `pulse(_:)` to receive one-shot events as an `AsyncStream`. Unlike state observation, pulse emits even when the same value is assigned again.
-
-```swift
-var body: some View {
-  ReactorObserving {
-    Text(reactor.username)
-  }
-  .task {
-    for await message in reactor.pulse(\.$alertMessage) {
-      guard let message else { continue }
-      // show alert
-    }
   }
 }
 ```

--- a/Sources/ReactorKitSwiftUI/ObservedReactor.swift
+++ b/Sources/ReactorKitSwiftUI/ObservedReactor.swift
@@ -233,37 +233,6 @@ extension ObservedReactor
 extension ObservedReactor: Observation.Observable {}
 #endif
 
-// MARK: - Pulse
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-extension ObservedReactor {
-  /// Returns an `AsyncStream` that emits the value of a `Pulse` property whenever it is updated.
-  ///
-  /// Unlike observing state properties directly, pulse streams emit even when the same value
-  /// is assigned again. This is useful for one-shot events like alerts or toasts.
-  ///
-  /// ```swift
-  /// .task {
-  ///   for await message in reactor.pulse(\.$alertMessage) {
-  ///     showAlert = true
-  ///   }
-  /// }
-  /// ```
-  public func pulse<Value: Sendable>(
-    _ transformToPulse: @escaping @Sendable (R.State) throws -> Pulse<Value>
-  ) -> AsyncStream<Value> {
-    let observable = reactor.pulse(transformToPulse)
-    return AsyncStream { continuation in
-      let disposable = observable
-        .subscribe(
-          onNext: { value in continuation.yield(value) },
-          onDisposed: { continuation.finish() }
-        )
-      continuation.onTermination = { @Sendable _ in disposable.dispose() }
-    }
-  }
-}
-
 // MARK: - binding(get:send:) helpers
 //
 // Vends closure-based `Binding`s that dispatch a supplied action on


### PR DESCRIPTION
## Summary
- Remove `ObservedReactor.pulse(_:) -> AsyncStream` and its README section
- Core `Reactor.pulse(_:) -> Observable` (RxSwift) is untouched

## Why
One-shot events in SwiftUI are better modeled as optional state driving `.alert(item:)` / `.sheet(item:)` than as an `AsyncStream` bridge over `Pulse`:
- `@Observable` ecosystems (TCA, Apple's own guidance) don't carry a Pulse-equivalent; exposing one in the SwiftUI layer pushed users toward a non-idiomatic pattern.
- The `AsyncStream` wrapper was subscribed inside `.task { }`, whose lifecycle restarts with view identity. Pulses emitted between restarts would be silently dropped — undermining the very guarantee Pulse exists to provide.
- `Optional<Value>` + explicit clear action keeps the one-shot semantic (nil → value → nil re-triggers) and stays in the reducer, where consumption is observable.

Not yet released, so removed outright instead of deprecated.

## Test plan
- [x] `swift build` passes
- [x] Existing `testPulseReactorStateCompiles` still compiles — it only verifies `@Pulse` state coexists with `ObservedReactor`, not the removed method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the pulse API previously available in the reactive framework.
* **Documentation**
  * Removed pulse-related documentation section and associated examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->