### PR TITLE
refactor(reactor): document action dispatch contract and add DEBUG check

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ final class MyReactor: Reactor {
 
 Notes:
 - The scheduler **must be serial**. Concurrent schedulers break the "single writer" invariant the reducer relies on.
-- `transform(action:)` runs on the action's emission thread, not `scheduler`. Downstream of `mutate(_:)` is the scheduled section.
+- **Action dispatch contract**: callers of `action.onNext(_:)` must be on a thread compatible with `scheduler` (default: main). The action upstream is not rescheduled, so sync dispatch from a compatible thread is preserved. In DEBUG builds an `os_log` fault is emitted when an action is dispatched from a non-main thread while `scheduler` is the default `MainScheduler` — custom schedulers are not checked.
+- `transform(action:)` runs on the caller's thread by design — this is the surface for stream-shaping operators (debounce, throttle, merge with other sources) where natural emission timing matters. The scheduled section starts downstream of `mutate(_:)`.
 - When using `ObservedReactor` for SwiftUI, keep the default `MainScheduler.instance`. Overriding to a non-main scheduler violates `ObservedReactor`'s main-actor contract.
 
 ### Pulse

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Suyeol Jeon. All rights reserved.
 //
 
+import Foundation
+
 import RxSwift
 @preconcurrency import WeakMapTable
 
@@ -45,9 +47,21 @@ public protocol Reactor: AnyObject {
   /// delivery happen on the scheduler even when `mutate(_:)` returns an observable
   /// that emits on a background thread (e.g. a network response).
   ///
-  /// `transform(action:)` runs on the action's emission thread, not this
-  /// scheduler. Override with a serial scheduler (e.g. `SerialDispatchQueueScheduler`)
-  /// to move reduction off the main thread.
+  /// **Action dispatch contract**: callers of `action.onNext(_:)` are responsible
+  /// for being on a thread compatible with `scheduler`. The action upstream is
+  /// not rescheduled, so sync dispatch semantics from a compatible thread are
+  /// preserved. In DEBUG builds an `os_log` fault is emitted when an action is
+  /// dispatched from a non-main thread while `scheduler` is the default
+  /// `MainScheduler` (custom schedulers are not checked — most do not expose
+  /// their queue context).
+  ///
+  /// `transform(action:)` runs on the caller's thread by design — this is the
+  /// surface for stream-shaping operators (debounce, throttle, merge with other
+  /// sources) where natural emission timing matters.
+  ///
+  /// Override with a serial scheduler (e.g. `SerialDispatchQueueScheduler`) to
+  /// move reduction off the main thread. The scheduler **must be serial**;
+  /// concurrent schedulers break the single-writer invariant of `reduce`.
   var scheduler: Scheduler { get }
 
   /// Transforms the action. Use this function to combine with other observables. This method is
@@ -127,15 +141,19 @@ extension Reactor {
 
   private func createReactorStreams() -> ReactorStreams<Action, State> {
     let actionSubject = ActionSubject<Action>()
-    let action = actionSubject.asObservable()
+    let baseAction = actionSubject.asObservable()
+    #if DEBUG
+    let action = baseAction.do(onNext: { [weak self] _ in self?._checkActionDispatchContext() })
+    #else
+    let action = baseAction
+    #endif
     let transformedAction = transform(action: action)
     let mutation = transformedAction
       .flatMap { [weak self] action -> Observable<Mutation> in
         guard let self = self else { return .empty() }
-        return self.mutate(action: action)
-          .catch { _ in .empty() }
-          .observe(on: self.scheduler)
+        return self.mutate(action: action).catch { _ in .empty() }
       }
+      .observe(on: scheduler)
     let transformedMutation = transform(mutation: mutation)
     let state = transformedMutation
       .scan(initialState) { [weak self] state, mutation -> State in
@@ -152,6 +170,21 @@ extension Reactor {
     transformedState.connect().disposed(by: disposeBag)
     return ReactorStreams(action: actionSubject, state: transformedState)
   }
+
+  #if DEBUG
+  /// DEBUG-only check that the action dispatch context is compatible with
+  /// `scheduler`. Currently checks the default `MainScheduler` case only;
+  /// custom schedulers do not expose enough queue context for a generic check.
+  /// See the `scheduler` property documentation for the dispatch contract.
+  fileprivate func _checkActionDispatchContext() {
+    guard scheduler is MainScheduler, !Thread.isMainThread else { return }
+    _runtimeWarning(
+      "\(type(of: self)).action received an action from a non-main thread, "
+        + "but `scheduler` is MainScheduler. Dispatch the action from the main "
+        + "thread, or override `scheduler` to match your dispatch context."
+    )
+  }
+  #endif
 
   public func transform(action: Observable<Action>) -> Observable<Action> {
     action

--- a/Sources/ReactorKit/RuntimeWarning.swift
+++ b/Sources/ReactorKit/RuntimeWarning.swift
@@ -1,0 +1,18 @@
+//
+//  RuntimeWarning.swift
+//  ReactorKit
+//
+//  Created by Kanghoon Oh on 4/20/26.
+//
+
+#if DEBUG
+import os.log
+
+private let _log = OSLog(subsystem: "com.reactorkit", category: "Reactor")
+
+/// Emits a runtime warning visible in Xcode's console as a fault-level os_log.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+func _runtimeWarning(_ message: @autoclosure () -> String) {
+  os_log(.fault, log: _log, "%{public}@", message())
+}
+#endif

--- a/Tests/ReactorKitTests/ReactorSchedulerTests.swift
+++ b/Tests/ReactorKitTests/ReactorSchedulerTests.swift
@@ -171,4 +171,94 @@ final class ReactorSchedulerTests: XCTestCase {
       XCTAssertFalse(thread.isMainThread)
     }
   }
+
+  /// Verifies the DEBUG action-dispatch contract check does not block or crash
+  /// the pipeline when an action is dispatched from a non-main thread under the
+  /// default `MainScheduler`. The `os_log` fault emission itself is observable
+  /// in Xcode's console; this test only guarantees the check is non-fatal and
+  /// preserves correctness so the warning surfaces a real misuse rather than a
+  /// regression.
+  func testActionDispatchContractCheckIsNonFatal() {
+    final class SimpleReactor: Reactor, @unchecked Sendable {
+      typealias Action = Void
+      typealias Mutation = Void
+
+      struct State {
+        var count = 0
+      }
+
+      let initialState = State()
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        newState.count += 1
+        return newState
+      }
+    }
+
+    let reactor = SimpleReactor()
+    let disposeBag = DisposeBag()
+    let expectation = XCTestExpectation()
+
+    reactor.state
+      .skip(1) // initial state
+      .subscribe(onNext: { state in
+        if state.count == 1 {
+          expectation.fulfill()
+        }
+      })
+      .disposed(by: disposeBag)
+
+    DispatchQueue.global().async {
+      reactor.action.onNext(Void())
+    }
+
+    XCTWaiter().wait(for: [expectation], timeout: 5)
+    XCTAssertEqual(reactor.currentState.count, 1)
+  }
+
+  /// Verifies the DEBUG check does not emit when a custom (non-MainScheduler)
+  /// scheduler is in use, even if the action is dispatched from a non-main
+  /// thread. There is no negative assertion against `os_log` (capture is
+  /// platform-dependent); this test pins behavior by exercising the early
+  /// `guard scheduler is MainScheduler` exit and confirming correctness.
+  func testActionDispatchContractCheckSkippedForCustomScheduler() {
+    final class SimpleReactor: Reactor, @unchecked Sendable {
+      typealias Action = Void
+      typealias Mutation = Void
+
+      struct State {
+        var count = 0
+      }
+
+      let initialState = State()
+      let scheduler: ImmediateSchedulerType = SerialDispatchQueueScheduler(qos: .default)
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        newState.count += 1
+        return newState
+      }
+    }
+
+    let reactor = SimpleReactor()
+    let disposeBag = DisposeBag()
+    let expectation = XCTestExpectation()
+
+    reactor.state
+      .skip(1)
+      .subscribe(onNext: { state in
+        if state.count == 1 {
+          expectation.fulfill()
+        }
+      })
+      .disposed(by: disposeBag)
+
+    DispatchQueue.global().async {
+      reactor.action.onNext(Void())
+    }
+
+    XCTWaiter().wait(for: [expectation], timeout: 5)
+    XCTAssertEqual(reactor.currentState.count, 1)
+  }
 }


### PR DESCRIPTION
## Summary
- Reframe `transform(action:)` on caller's thread as the intended dispatch contract (not a caveat). The action upstream is not rescheduled, so sync dispatch from a compatible thread is preserved.
- Add a DEBUG-only `os_log` fault in `Reactor` when an action is dispatched from a non-main thread under the default `MainScheduler`. Custom schedulers are not checked because most do not expose their queue context.
- Move `observe(on: scheduler)` outside the `flatMap` — the scheduler boundary is now applied once to the merged mutation stream instead of being re-applied per effect.
- Update README "Scheduling > Notes" to state the dispatch contract directly.

## Why
The previous wording in `464eb51` framed the unscheduled action upstream as a "caveat", but rescheduling it would require a second `observe(on: scheduler)` hop that breaks `MainScheduler`'s sync trampolining (verified — three existing tests fail when the second hop is added). The correct model is to make the caller responsibility explicit and surface misuse via a DEBUG runtime check.

## Test plan
- [x] `swift test` — 145 tests pass, no regressions
- [x] New `testActionDispatchContractCheckIsNonFatal` — confirms DEBUG check does not block or crash the pipeline when an action is dispatched from a background thread under `MainScheduler`
- [x] New `testActionDispatchContractCheckSkippedForCustomScheduler` — confirms the early `guard scheduler is MainScheduler` exit when a custom scheduler is in use
- [x] Manual: verify the `os_log` fault appears in Xcode's console when reproducing the misuse pattern (not asserted in tests; capture is platform-dependent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated action dispatching requirements documentation to clarify threading contract.

* **Improvements**
  * Added DEBUG-only runtime warnings to help identify incorrect action dispatch patterns from incompatible threads.

* **Tests**
  * Added test coverage for action dispatch behavior under various threading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->