### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class ProfileViewController: UIViewController, ReactorView {
   var disposeBag = DisposeBag()
 }
 
-profileViewController.reactor = UserViewReactor() // inject reactor
+profileViewController.reactor = ProfileViewReactor() // inject reactor
 ```
 
 When the `reactor` property has changed, `bind(reactor:)` gets called. Implement this method to define the bindings of an action stream and a state stream.


### PR DESCRIPTION
- Fix inconsistent naming in the README View example.
- Rename `UserViewReactor` to `ProfileViewReactor` for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UIKit view integration example to ensure consistency with accompanying code samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->