### PR TITLE
Fix Observable.just(...) in GitHubSearch tutorial

### DIFF
--- a/Documentation/Tutorials/GitHubSearch/4-ImplementingReactor.md
+++ b/Documentation/Tutorials/GitHubSearch/4-ImplementingReactor.md
@@ -17,7 +17,7 @@ func mutate(action: Action) -> Observable<Mutation> {
         .catchErrorJustReturn([])
         .map { Mutation.setRepos($0) }
     } else {
-      return Observabe.just(Mutation.setRepos([])) // empty result
+      return Observable.just(Mutation.setRepos([])) // empty result
     }
   }
 }


### PR DESCRIPTION
- Corrects `Observabe.just(...)` to `Observable.just(...)` in the Implementing Reactor section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the GitHub Search tutorial code example to ensure correct compilation and proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->