### PR TITLE
feat(reactor): restore reentrancy trampoline as internal mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,9 +373,31 @@ func testIsLoading() {
 
 ### Threading
 
-ReactorKit does not reschedule the pipeline on your behalf. `transform(action:)`, `mutate(_:)`, `transform(mutation:)`, `reduce(_:_:)`, `transform(state:)`, and state subscribers all run on whatever thread the upstream emits on.
+ReactorKit does not move work between threads on your behalf. With one exception (the reentrancy trampoline described below), `transform(action:)`, `mutate(_:)`, `transform(mutation:)`, `reduce(_:_:)`, `transform(state:)`, and state subscribers all run on whatever thread the upstream emits on.
 
-**Action dispatch contract**: callers of `action.onNext(_:)` are expected to dispatch from the main thread. This keeps action entry into the pipeline serialized. The same rule applies to any external stream merged inside `transform(action:)` — apply `.observe(on: MainScheduler.instance)` to it before merging. In DEBUG builds an `os_log` fault is emitted when an action reaches `mutate(_:)` off the main thread.
+#### Responsibility split
+
+| Guarantee | Owner |
+|---|---|
+| Same-thread reentrant action serialization | ReactorKit (internal trampoline) |
+| Main-thread action dispatch | User (DEBUG warning emitted on violation) |
+| `mutate` background → main hop | User (`.observe(on: MainScheduler.instance)` inside `mutate`) |
+| UIKit transition serialization (e.g. dismiss → present) | User (`MainScheduler.asyncInstance` or `dismiss(completion:)`) |
+| SwiftUI main-thread state delivery | ReactorKit (`ObservedReactor.init`) |
+
+#### Why the trampoline exists
+
+The action upstream is observed on `CurrentThreadScheduler.instance`. When an action is dispatched from inside `reduce(_:_:)` or a state subscriber — i.e. while a previous emission is still on the stack — the new action is queued on the current thread and processed only after the in-flight emission completes. Without this trampoline, a reentrant action's `reduce` would run before the outer emission's state subscribers finished, which is a common source of reordering bugs (for example, a `dismiss` followed by a `present` from the dismiss handler can break routing if the second action interrupts the first emission).
+
+#### Why `Reactor.scheduler` is not exposed
+
+The trampoline is a reentrancy-safety mechanism, not a thread-placement policy. Thread-moving schedulers (`MainScheduler`, `SerialDispatchQueueScheduler`) belong inside `mutate(_:)` via explicit `.observe(on:)` so the hop is local to the effect that needs it. An earlier iteration (PR #256) exposed a `scheduler` property defaulting to `MainScheduler.instance`; this reintroduced races between `mutate(_:)` and `currentState` writes and broke the synchronous `action.onNext → reduce → currentState` contract that `currentState` readers depend on. Keeping thread placement at the call site preserves that contract and prevents the framework from silently reordering caller-controlled work.
+
+#### Action dispatch contract
+
+Callers of `action.onNext(_:)` are expected to dispatch from the main thread. This keeps action entry into the pipeline serialized. The same rule applies to any external stream merged inside `transform(action:)` — apply `.observe(on: MainScheduler.instance)` to it before merging. In DEBUG builds an `os_log` fault is emitted when an action reaches `mutate(_:)` off the main thread.
+
+#### Recipes
 
 If `mutate(_:)` returns an observable that emits from a background thread (e.g. a network response), apply `.observe(on:)` explicitly to hop back onto a thread compatible with your consumers:
 
@@ -391,6 +413,19 @@ func mutate(action: Action) -> Observable<Mutation> {
 ```
 
 The same applies when `transform(mutation:)` merges an external stream — the merged source bypasses the action-dispatch boundary, so make sure its emissions land on the same thread your other mutations do.
+
+For UIKit transitions where one action must complete before the next runs (e.g. `dismiss` → `present`), use `MainScheduler.asyncInstance` so the next action is scheduled on the next runloop turn instead of nesting inside the current one:
+
+```swift
+reactor.state.map(\.shouldDismiss)
+  .filter { $0 }
+  .observe(on: MainScheduler.asyncInstance)
+  .subscribe(onNext: { [weak self] _ in
+    self?.dismiss(animated: true)
+    self?.reactor?.action.onNext(.presentNext)
+  })
+  .disposed(by: disposeBag)
+```
 
 `reduce(_:_:)` is expected to be single-writer. ReactorKit does not enforce this — if you fan mutations in from multiple threads, `currentState` can race. Keep mutation emissions on a single thread.
 

--- a/Sources/ReactorKit/Reactor.swift
+++ b/Sources/ReactorKit/Reactor.swift
@@ -125,7 +125,12 @@ extension Reactor {
 
   private func createReactorStreams() -> ReactorStreams<Action, State> {
     let actionSubject = ActionSubject<Action>()
-    let action = actionSubject.asObservable()
+    // Trampoline serialization on the current thread. Internal reentrancy-safety
+    // mechanism — not a configurable scheduler. Actions dispatched from inside
+    // reduce or a state subscriber are queued and processed after the current
+    // emission completes. Thread placement remains the caller's responsibility
+    // (see action property docs).
+    let action = actionSubject.asObservable().observe(on: CurrentThreadScheduler.instance)
     let baseTransformedAction = transform(action: action)
     #if DEBUG
     let transformedAction = baseTransformedAction.do(onNext: { [weak self] _ in

--- a/Tests/ReactorKitTests/ReactorReentrancyTests.swift
+++ b/Tests/ReactorKitTests/ReactorReentrancyTests.swift
@@ -1,0 +1,189 @@
+//
+//  ReactorReentrancyTests.swift
+//  ReactorKit
+//
+//  Created by Kanghoon Oh on 4/30/26.
+//
+
+import XCTest
+
+import ReactorKit
+@preconcurrency import RxSwift
+
+@preconcurrency
+final class ReactorReentrancyTests: XCTestCase {
+
+  func test_reentrantActionFromStateSubscriber_isSerialized() {
+    final class LogReactor: Reactor, @unchecked Sendable {
+      enum Action {
+        case a
+        case b
+      }
+
+      enum Mutation {
+        case enterA
+        case exitA
+        case enterB
+        case exitB
+      }
+
+      struct State {
+        var log: [String] = []
+      }
+
+      let initialState = State()
+
+      func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .a:
+          return .from([.enterA, .exitA])
+        case .b:
+          return .from([.enterB, .exitB])
+        }
+      }
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .enterA: newState.log.append("enter A")
+        case .exitA: newState.log.append("exit A")
+        case .enterB: newState.log.append("enter B")
+        case .exitB: newState.log.append("exit B")
+        }
+        return newState
+      }
+    }
+
+    let reactor = LogReactor()
+    let disposeBag = DisposeBag()
+    var didDispatchB = false
+
+    reactor.state
+      .subscribe(onNext: { state in
+        if !didDispatchB && state.log.contains("enter A") {
+          didDispatchB = true
+          reactor.action.onNext(.b)
+        }
+      })
+      .disposed(by: disposeBag)
+
+    reactor.action.onNext(.a)
+
+    XCTAssertEqual(
+      reactor.currentState.log,
+      ["enter A", "exit A", "enter B", "exit B"]
+    )
+  }
+
+  func test_reentrantActionFromReduce_doesNotRecurse() {
+    final class LogReactor: Reactor, @unchecked Sendable {
+      enum Action {
+        case a
+        case b
+      }
+
+      enum Mutation {
+        case enterA
+        case exitA
+        case enterB
+        case exitB
+      }
+
+      struct State {
+        var log: [String] = []
+      }
+
+      let initialState = State()
+      private var didTriggerFollowUp = false
+
+      func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .a:
+          return .from([.enterA, .exitA])
+        case .b:
+          return .from([.enterB, .exitB])
+        }
+      }
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .enterA:
+          newState.log.append("enter A")
+          if !didTriggerFollowUp {
+            didTriggerFollowUp = true
+            action.onNext(.b)
+          }
+        case .exitA: newState.log.append("exit A")
+        case .enterB: newState.log.append("enter B")
+        case .exitB: newState.log.append("exit B")
+        }
+        return newState
+      }
+    }
+
+    let reactor = LogReactor()
+    _ = reactor.state.subscribe()
+
+    reactor.action.onNext(.a)
+
+    XCTAssertEqual(
+      reactor.currentState.log,
+      ["enter A", "exit A", "enter B", "exit B"]
+    )
+  }
+
+  func test_dismissThenPresent_routingPattern() {
+    final class RouteReactor: Reactor, @unchecked Sendable {
+      enum Action {
+        case dismiss
+        case present(String)
+      }
+
+      enum Mutation {
+        case setRoute(String?)
+      }
+
+      struct State {
+        var route: String?
+      }
+
+      let initialState = State(route: "initial")
+
+      func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .dismiss:
+          return .just(.setRoute(nil))
+        case .present(let route):
+          return .just(.setRoute(route))
+        }
+      }
+
+      func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setRoute(let route):
+          newState.route = route
+        }
+        return newState
+      }
+    }
+
+    let reactor = RouteReactor()
+    let disposeBag = DisposeBag()
+    var didPresent = false
+
+    reactor.state
+      .subscribe(onNext: { state in
+        if !didPresent && state.route == nil {
+          didPresent = true
+          reactor.action.onNext(.present("next"))
+        }
+      })
+      .disposed(by: disposeBag)
+
+    reactor.action.onNext(.dismiss)
+
+    XCTAssertEqual(reactor.currentState.route, "next")
+  }
+}


### PR DESCRIPTION
## Summary

- Re-applies `.observe(on: CurrentThreadScheduler.instance)` to the action upstream inside `createReactorStreams()`, restoring the reentrancy serialization that 3.2.0 provided through `Reactor.scheduler` and that #257 inadvertently removed alongside the scheduler API.
- Keeps `Reactor.Scheduler` typealias and the `scheduler` protocol requirement removed — the trampoline is treated as an internal reentrancy-safety mechanism (analogous to TCA's `bufferedActions + isSending`), not a configurable scheduler.
- Updates the README Threading section around an explicit responsibility split: reentrancy is the framework's, thread placement remains the caller's.

## Motivation

Real-world symptom: dismiss → present routing patterns where a state subscriber re-dispatches an action would lose the follow-up. Without the trampoline, the second action's emission interrupted the first instead of being queued behind it, so the routing state ended up reordered.

The fix preserves #257's responsibility split — the framework still does not move work between threads on its behalf — while restoring the same-thread serialization guarantee that 7 years of code already depended on.

## Why not re-expose `Reactor.scheduler`?

#256 briefly restored `scheduler` with a `MainScheduler.instance` default. Three concrete failure modes from the #257 retrospective remain valid reasons to keep the API hidden:

- `transform(mutation:)` merging an external stream bypassed the effect-boundary hop, so `reduce` could still run off-scheduler.
- `mutate(_:)` ran on the caller thread while `currentState` writes ran on `scheduler`, allowing races and stale reads.
- The synchronous `action.onNext → reduce → currentState` contract broke when the pipeline hop was introduced.

`CurrentThreadScheduler.instance` does not move work between threads — it only queues reentrant emissions on the current thread — so none of those failure modes apply. Thread-moving schedulers (`MainScheduler`, `SerialDispatchQueueScheduler`) belong inside `mutate(_:)` via explicit `.observe(on:)`.

## Changes

- `Sources/ReactorKit/Reactor.swift` — single `.observe(on: CurrentThreadScheduler.instance)` on the action upstream + intent-explaining comment. No protocol or extension surface added. DEBUG `_checkActionDispatchContext` untouched.
- `Tests/ReactorKitTests/ReactorReentrancyTests.swift` (new) — three regression cases: reentrant action from a state subscriber, reentrant action from inside `reduce`, and the dismiss → present routing pattern.
- `README.md` — Threading section restructured: 5-row responsibility table, "Why the trampoline exists", "Why `Reactor.scheduler` is not exposed" preserving the #256 retrospective, plus a `MainScheduler.asyncInstance` recipe for UIKit transitions that need to span runloop boundaries.

`ReactorDispatchTests` (PR #257 invariants — synchronous contract and DEBUG dispatch check) continues to pass.

## Test plan

- [x] `swift test` — 145 tests, 0 failures
- [x] `ReactorReentrancyTests` — 3/3 passing
- [x] `ReactorDispatchTests` — still passing
- [x] Verify CI green on macOS / iOS / tvOS schemes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Threading documentation with clarified execution semantics, responsibility splits, and reentrancy-safety details.
  * Added new UIKit recipe demonstrating best practices for action dispatching to prevent nesting issues.

* **Improvements**
  * Strengthened reentrancy-safety by ensuring actions dispatched during state mutations are properly serialized and handled sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->