### PR TITLE
docs(readme): trim Threading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,31 +373,18 @@ func testIsLoading() {
 
 ### Threading
 
-ReactorKit does not move work between threads on your behalf. With one exception (the reentrancy trampoline described below), `transform(action:)`, `mutate(_:)`, `transform(mutation:)`, `reduce(_:_:)`, `transform(state:)`, and state subscribers all run on whatever thread the upstream emits on.
-
-#### Responsibility split
+ReactorKit does not move work between threads on your behalf. `transform(action:)`, `mutate(_:)`, `transform(mutation:)`, `reduce(_:_:)`, `transform(state:)`, and state subscribers all run on whatever thread the upstream emits on.
 
 | Guarantee | Owner |
 |---|---|
-| Same-thread reentrant action serialization | ReactorKit (internal trampoline) |
-| Main-thread action dispatch | User (DEBUG warning emitted on violation) |
-| `mutate` background → main hop | User (`.observe(on: MainScheduler.instance)` inside `mutate`) |
-| UIKit transition serialization (e.g. dismiss → present) | User (`MainScheduler.asyncInstance` or `dismiss(completion:)`) |
-| SwiftUI main-thread state delivery | ReactorKit (`ObservedReactor.init`) |
+| Same-thread reentrant action serialization | ReactorKit |
+| Main-thread action dispatch | You (DEBUG warning on violation) |
+| `mutate` background → main hop | You (`.observe(on:)` inside `mutate`) |
+| SwiftUI main-thread state delivery | ReactorKit (`ObservedReactor`) |
 
-#### Why the trampoline exists
+**Action dispatch contract**: callers of `action.onNext(_:)` are expected to dispatch from the main thread. This keeps action entry into the pipeline serialized. The same rule applies to any external stream merged inside `transform(action:)` — apply `.observe(on: MainScheduler.instance)` to it before merging. In DEBUG builds an `os_log` fault is emitted when an action reaches `mutate(_:)` off the main thread.
 
-The action upstream is observed on `CurrentThreadScheduler.instance`. When an action is dispatched from inside `reduce(_:_:)` or a state subscriber — i.e. while a previous emission is still on the stack — the new action is queued on the current thread and processed only after the in-flight emission completes. Without this trampoline, a reentrant action's `reduce` would run before the outer emission's state subscribers finished, which is a common source of reordering bugs (for example, a `dismiss` followed by a `present` from the dismiss handler can break routing if the second action interrupts the first emission).
-
-#### Why `Reactor.scheduler` is not exposed
-
-The trampoline is a reentrancy-safety mechanism, not a thread-placement policy. Thread-moving schedulers (`MainScheduler`, `SerialDispatchQueueScheduler`) belong inside `mutate(_:)` via explicit `.observe(on:)` so the hop is local to the effect that needs it. An earlier iteration (PR #256) exposed a `scheduler` property defaulting to `MainScheduler.instance`; this reintroduced races between `mutate(_:)` and `currentState` writes and broke the synchronous `action.onNext → reduce → currentState` contract that `currentState` readers depend on. Keeping thread placement at the call site preserves that contract and prevents the framework from silently reordering caller-controlled work.
-
-#### Action dispatch contract
-
-Callers of `action.onNext(_:)` are expected to dispatch from the main thread. This keeps action entry into the pipeline serialized. The same rule applies to any external stream merged inside `transform(action:)` — apply `.observe(on: MainScheduler.instance)` to it before merging. In DEBUG builds an `os_log` fault is emitted when an action reaches `mutate(_:)` off the main thread.
-
-#### Recipes
+**Reentrant actions**: an action dispatched from inside `reduce(_:_:)` or a state subscriber is queued on the current thread's trampoline and processed after the in-flight emission completes. Without this, the reentrant action's `reduce` could interrupt the outer emission and reorder state changes — e.g. a `dismiss` followed by a `present` from the dismiss handler.
 
 If `mutate(_:)` returns an observable that emits from a background thread (e.g. a network response), apply `.observe(on:)` explicitly to hop back onto a thread compatible with your consumers:
 
@@ -413,19 +400,6 @@ func mutate(action: Action) -> Observable<Mutation> {
 ```
 
 The same applies when `transform(mutation:)` merges an external stream — the merged source bypasses the action-dispatch boundary, so make sure its emissions land on the same thread your other mutations do.
-
-For UIKit transitions where one action must complete before the next runs (e.g. `dismiss` → `present`), use `MainScheduler.asyncInstance` so the next action is scheduled on the next runloop turn instead of nesting inside the current one:
-
-```swift
-reactor.state.map(\.shouldDismiss)
-  .filter { $0 }
-  .observe(on: MainScheduler.asyncInstance)
-  .subscribe(onNext: { [weak self] _ in
-    self?.dismiss(animated: true)
-    self?.reactor?.action.onNext(.presentNext)
-  })
-  .disposed(by: disposeBag)
-```
 
 `reduce(_:_:)` is expected to be single-writer. ReactorKit does not enforce this — if you fan mutations in from multiple threads, `currentState` can race. Keep mutation emissions on a single thread.
 


### PR DESCRIPTION
## Summary

Trim the Threading section that grew in #260. The added sub-headers, design retrospective, and UIKit-specific recipe make the section longer than it needs to be for a library README.

## Changes

- Fold the five sub-headers (`Responsibility split`, `Why the trampoline exists`, `Why Reactor.scheduler is not exposed`, `Action dispatch contract`, `Recipes`) back into inline paragraphs. The trampoline rationale is preserved as a single bold-prefixed sentence.
- Drop the **Why Reactor.scheduler is not exposed** paragraph entirely. It documents the #256 → #257 design history, which belongs in PR descriptions, not in user-facing docs.
- Drop the **dismiss → present `MainScheduler.asyncInstance` recipe**. It is a generic RxSwift technique, not a property of the ReactorKit pipeline.
- Slim the responsibility table from 5 rows to 4 (drop the UIKit transition row) and remove redundant parenthetical detail (`(internal trampoline)`, etc.).

## Diff size

- vs. PR #260 baseline: -33 lines
- vs. pre-#260 (#257) baseline: +7 lines

The trampoline guarantee, the dispatch contract, the `mutate` background-hop recipe, the single-writer caveat, and the SwiftUI delivery note are all preserved.

## Test plan

- [x] Read-through of the Threading section end-to-end for coherence
- [x] No code or test changes; library behavior unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified and condensed the Threading section of the README.
  * Streamlined responsibility mappings and removed detailed examples for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->