### PR TITLE
fix(swiftui): close native Observation race after BG → main hop

### DIFF
--- a/Sources/ReactorKitSwiftUI/ObservedReactor.swift
+++ b/Sources/ReactorKitSwiftUI/ObservedReactor.swift
@@ -140,26 +140,81 @@ public final class ObservedReactor<R: Reactor> where R.State: ObservableState {
   private var disposeBag = DisposeBag()
 
   /// Creates an observed reactor, subscribing to the reactor's state
-  /// stream and routing every emission through the `state` setter so
+  /// stream and routing every emission through ``_runOnMain(_:)`` so
   /// observation notifications fire on the main actor.
-  ///
-  /// State emissions are hopped onto `MainScheduler.instance` before the
-  /// `assumeIsolated` call below. The Reactor pipeline does not reschedule
-  /// on its own, so `mutate(_:)` can return observables that emit from
-  /// background threads. Observing on main here guarantees the
-  /// `@MainActor` contract regardless of how the reactor's mutations
-  /// dispatch.
   public init(reactor: R) {
     self.reactor = reactor
     self._state = reactor.initialState
     reactor.state
-      .observe(on: MainScheduler.instance)
       .subscribe(onNext: { [weak self] state in
-        MainActor.assumeIsolated {
+        self?._runOnMain { [weak self] in
           self?.state = state
         }
       })
       .disposed(by: disposeBag)
+  }
+
+  /// Runs `block` on the main thread — synchronously when already on
+  /// main, otherwise via `DispatchQueue.main.async`.
+  ///
+  /// # Why not `.observe(on: MainScheduler.instance)`?
+  ///
+  /// `MainScheduler.instance` shares a process-wide `numberEnqueued`
+  /// counter. If `mutate(_:)` returns a chain that itself uses
+  /// `.observe(on: MainScheduler.instance)` (a common BG → main hop),
+  /// the counter is non-zero when the resulting state reaches our
+  /// subscriber. RxSwift then falls back from the synchronous fast-path
+  /// to `dispatch_async`, deferring `_state = newValue` to a later
+  /// runloop turn.
+  ///
+  /// That deferral races against native Observation: the macro setters
+  /// fire `Observation.ObservationRegistrar.willSet` synchronously
+  /// inside `reduce`, SwiftUI schedules a body re-eval, and the
+  /// re-evaluation runs **before** the deferred `_state = newValue`. The
+  /// body reads stale `_state` — UI sticks on the previous state.
+  ///
+  /// A direct `Thread.isMainThread` check is independent of any
+  /// scheduler counter, so the sync fast-path is always taken when the
+  /// upstream emits on main. `_state = newValue` then happens in the
+  /// same call stack as the macro's willSet, and any scheduled body
+  /// re-eval observes the fresh state.
+  ///
+  /// # Background-thread emissions
+  ///
+  /// The Reactor pipeline does not reschedule on its own, so `mutate(_:)`
+  /// can return observables that emit from background threads. The
+  /// `else` branch handles that with an async hop — at the cost of one
+  /// runloop tick of perceived UI lag.
+  ///
+  /// Note that the user-reported race described above only manifests
+  /// when the upstream emits **on main** (e.g. after a user-supplied
+  /// `.observe(on: MainScheduler.instance)` hop): the macro's native
+  /// `willSet` fires on main inside `reduce`, SwiftUI scheduled body
+  /// re-eval, and `_state = newValue` had to land before that re-eval.
+  /// True BG emissions are an Apple-discouraged pattern (SwiftUI
+  /// Observation expects mutations on main); in that case the macro's
+  /// willSet fires on the background thread the upstream emitted from,
+  /// and downstream SwiftUI behavior follows Apple's contract for
+  /// off-main mutations rather than anything this helper can guarantee.
+  ///
+  /// # Concurrency
+  ///
+  /// `nonisolated` because RxSwift's subscribe closure is not
+  /// actor-isolated. The `@MainActor` closure parameter (gated by
+  /// `Thread.isMainThread` / `DispatchQueue.main`) bridges into
+  /// main-actor-isolated work via `MainActor.assumeIsolated`. The
+  /// `else` branch's `assumeIsolated` is sound because
+  /// `DispatchQueue.main.async` enqueues onto the main queue, which is
+  /// the main actor's executor on Apple platforms — the runtime check
+  /// passes.
+  private nonisolated func _runOnMain(_ block: @escaping @MainActor () -> Void) {
+    if Thread.isMainThread {
+      MainActor.assumeIsolated(block)
+    } else {
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated(block)
+      }
+    }
   }
 
   /// Sends an action to the reactor.

--- a/Sources/ReactorKitSwiftUI/ReactorObserving.swift
+++ b/Sources/ReactorKitSwiftUI/ReactorObserving.swift
@@ -89,10 +89,10 @@ extension ReactorObserving: View where Content: View {
       // SwiftUI re-evaluates the surrounding body, restarting tracking.
       let _ = id
       // `MainActor.assumeIsolated` is safe here because:
-      // - ObservedReactor is @MainActor and its init hops the reactor
-      //   state stream onto MainScheduler before writing to `state`,
-      //   so the setter always runs on the main thread regardless of
-      //   where the Reactor pipeline emitted from.
+      // - ObservedReactor is @MainActor and its init routes every state
+      //   emission through `_runOnMain(_:)`, which guarantees `state.set`
+      //   runs on the main thread regardless of which thread the Reactor
+      //   pipeline emitted from.
       // - BackportRegistrar.willSet (which fires this callback) is
       //   called from that setter.
       // - Using async dispatch would defer the @State update, causing a

--- a/Tests/ReactorKitSwiftUITests/NativeStateObservationProbeTests.swift
+++ b/Tests/ReactorKitSwiftUITests/NativeStateObservationProbeTests.swift
@@ -60,6 +60,126 @@ private final class ProbeReactor: Reactor {
   }
 }
 
+/// Reactor whose `.increase` mutation hops BG → Main inside `Observable.concat`
+/// before emitting the value-changing mutation. Mirrors the user-reported
+/// pattern from `Examples/SwiftUICounter`.
+@ObservableState
+private struct BackgroundHopState {
+  var count = 0
+  var isLoading = false
+}
+
+/// Trampoline that mirrors SwiftUI's `withObservationTracking` lifecycle:
+/// each `onChange` fire schedules an async snapshot of the reactor's state,
+/// then re-installs tracking. Captures successive snapshots so the test can
+/// assert on the post-mutation values that SwiftUI body would read.
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@MainActor
+private final class _BackgroundHopTrampoline {
+  let reactor: ObservedReactor<BackgroundHopReactor>
+  var snapshots: [(isLoading: Bool, count: Int)] = []
+  var bothFires: XCTestExpectation?
+
+  init(reactor: ObservedReactor<BackgroundHopReactor>) {
+    self.reactor = reactor
+  }
+
+  func trackAndCapture() {
+    withObservationTracking {
+      _ = reactor.isLoading
+      _ = reactor.count
+    } onChange: { [weak self] in
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          guard let self else { return }
+          self.snapshots.append((self.reactor.isLoading, self.reactor.count))
+          self.bothFires?.fulfill()
+          if self.snapshots.count < 2 {
+            self.trackAndCapture()
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Trampoline that re-tracks until it captures a snapshot whose `count`
+/// matches `targetCount` — the value the next `.increaseValue` mutation
+/// will produce. Used by the sequential pin test where each `.increase`
+/// completes before the next is sent.
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@MainActor
+private final class _BackgroundHopValueCaptureTrampoline {
+  let reactor: ObservedReactor<BackgroundHopReactor>
+  var targetCount: Int = 0
+  var captured: XCTestExpectation?
+  var onCapture: ((Int) -> Void)?
+
+  init(reactor: ObservedReactor<BackgroundHopReactor>) {
+    self.reactor = reactor
+  }
+
+  func trackAndCapture() {
+    withObservationTracking {
+      _ = reactor.isLoading
+      _ = reactor.count
+    } onChange: { [weak self] in
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          guard let self else { return }
+          let count = self.reactor.count
+          if count == self.targetCount && !self.reactor.isLoading {
+            self.onCapture?(count)
+            self.captured?.fulfill()
+          } else {
+            self.trackAndCapture()
+          }
+        }
+      }
+    }
+  }
+}
+
+private final class BackgroundHopReactor: Reactor {
+  enum Action { case increase }
+  enum Mutation {
+    case setLoading(Bool)
+    case increaseValue
+  }
+
+  let initialState = BackgroundHopState()
+
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .increase:
+      return Observable.concat([
+        .just(.setLoading(true)),
+        Observable.create { observer in
+          observer.onNext(())
+          observer.onCompleted()
+          return Disposables.create()
+        }
+        .subscribe(on: SerialDispatchQueueScheduler(qos: .userInteractive))
+        .observe(on: MainScheduler.instance)
+        .flatMap { Observable<Mutation>.empty() },
+        Observable.just(.increaseValue),
+      ])
+    }
+  }
+
+  func reduce(state: BackgroundHopState, mutation: Mutation) -> BackgroundHopState {
+    var state = state
+    switch mutation {
+    case .setLoading(let loading):
+      state.isLoading = loading
+    case .increaseValue:
+      state.count += 1
+      state.isLoading = false
+    }
+    return state
+  }
+}
+
 @available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
 final class NativeStateObservationProbeTests: XCTestCase {
 
@@ -176,6 +296,101 @@ final class NativeStateObservationProbeTests: XCTestCase {
     stateB.count = 99
 
     wait(for: [onChangeFired], timeout: 1.0)
+  }
+
+  /// Reproduces the BG-hop + native Observation race that pins SwiftUI's
+  /// body to a stale `_state`.
+  ///
+  /// The user-reported pattern: `mutate(.increase)` returns a `concat` of
+  /// `[setLoading(true), Observable.create+subscribe(on:bg)+observe(on:MainScheduler.instance)+flatMap{empty},
+  /// just(.increaseValue)]`. The inner `.observe(on: MainScheduler.instance)`
+  /// increments `MainScheduler.instance.numberEnqueued`, so when
+  /// `ObservedReactor.init`'s nested `.observe(on: MainScheduler.instance)`
+  /// is reached for delivering the `.increaseValue` state, it falls through
+  /// to `dispatch_async`. Meanwhile the macro's `_$mutate` fires native
+  /// Observation `willSet` synchronously inside `reduce`. SwiftUI schedules
+  /// body re-eval in response — and that re-eval runs BEFORE the deferred
+  /// `_state = newValue` assignment, so body reads the previous state.
+  ///
+  /// The test mirrors SwiftUI's behavior by capturing state inside an
+  /// async block scheduled from `withObservationTracking`'s `onChange`.
+  /// With the race present, the second snapshot reads stale state
+  /// (`isLoading=true, count=0`) instead of the post-`.increaseValue`
+  /// state (`isLoading=false, count=1`).
+  @MainActor
+  func testBodyReEvaluatesAgainstFreshStateAfterBackgroundHop() {
+    let reactor = ObservedReactor(reactor: BackgroundHopReactor())
+
+    let trampoline = _BackgroundHopTrampoline(reactor: reactor)
+    trampoline.bothFires = expectation(description: "two body re-eval snapshots captured")
+    trampoline.bothFires?.expectedFulfillmentCount = 2
+
+    trampoline.trackAndCapture()
+
+    reactor.send(.increase)
+
+    wait(for: [trampoline.bothFires!], timeout: 3.0)
+
+    XCTAssertEqual(trampoline.snapshots.count, 2, "expected 2 onChange-driven snapshots")
+
+    // Snapshot 0 is from `.setLoading(true)` — sync delivery, fresh state.
+    XCTAssertTrue(trampoline.snapshots[0].isLoading, "snapshot 0 (post-setLoading) should see isLoading=true")
+    XCTAssertEqual(trampoline.snapshots[0].count, 0, "snapshot 0 (post-setLoading) should see count=0")
+
+    // Snapshot 1 is from `.increaseValue` after the BG hop. With the bug,
+    // SwiftUI body re-eval reads stale `_state` because `_state = newValue`
+    // is deferred past the body re-eval.
+    XCTAssertEqual(
+      trampoline.snapshots[1].count, 1,
+      "snapshot 1 (post-increaseValue) should see count=1 — body re-eval read stale `_state`"
+    )
+    XCTAssertFalse(
+      trampoline.snapshots[1].isLoading,
+      "snapshot 1 (post-increaseValue) should see isLoading=false — body re-eval read stale `_state`"
+    )
+  }
+
+  /// Pins the BG-hop body-race fix against future regressions.
+  ///
+  /// Issues 5 sequential `.increase` actions, each completing before the
+  /// next is sent. For every `.increase`, the test installs a fresh
+  /// `withObservationTracking` scope mirroring SwiftUI's per-render
+  /// tracking, then captures the post-mutation `(isLoading, count)`
+  /// snapshot through the async block scheduled from `onChange`.
+  ///
+  /// Asserts that each captured snapshot reflects the post-`.increaseValue`
+  /// state — `count` strictly increasing 1, 2, 3, 4, 5 — i.e., body re-eval
+  /// always reads fresh `_state` regardless of how many times the
+  /// reactor pipeline has bumped any process-wide scheduler counter on
+  /// previous mutations.
+  ///
+  /// If the `_state = newValue` assignment ever regresses to deferred
+  /// scheduling (the original race), the captured count would either
+  /// stick at the previous value or skip — and this test would catch it.
+  @MainActor
+  func testRepeatedBackgroundHopMutationsPinFreshStateReads() {
+    let reactor = ObservedReactor(reactor: BackgroundHopReactor())
+
+    var capturedCounts: [Int] = []
+
+    for expected in 1...5 {
+      let trampoline = _BackgroundHopValueCaptureTrampoline(reactor: reactor)
+      trampoline.targetCount = expected
+      trampoline.captured = expectation(description: "captured count=\(expected)")
+      trampoline.onCapture = { capturedCounts.append($0) }
+      trampoline.trackAndCapture()
+
+      reactor.send(.increase)
+
+      wait(for: [trampoline.captured!], timeout: 2.0)
+    }
+
+    XCTAssertEqual(
+      capturedCounts, [1, 2, 3, 4, 5],
+      "each body re-eval should read the post-`.increaseValue` count — got \(capturedCounts)"
+    )
+    XCTAssertFalse(reactor.isLoading)
+    XCTAssertEqual(reactor.count, 5)
   }
 
   func testPerPropertyScopingReaderNotInvalidatedByOtherPropertyWrite() {


### PR DESCRIPTION
## Summary

- Fixes a race in `ObservedReactor` where SwiftUI views stuck on stale state after a `mutate(_:)` chain that hops BG → main via `.observe(on: MainScheduler.instance)` and then emits a state-changing mutation
- Replaces `.observe(on: MainScheduler.instance)` in `init(reactor:)` with a hand-rolled hop (`_runOnMain(_:)`) — `Thread.isMainThread ? sync : DispatchQueue.main.async` — independent of RxSwift's process-wide `numberEnqueued` counter
- Adds two regression tests; both fail on `main` and pass on the fix

## Bug

A user reported that after this `.increase` mutation pattern (counter sample), the UI sticks on the loading state and `count` never advances even though `currentState` reflects the new value:

```swift
case .increase:
  guard !currentState.isLoading else { return .empty() }
  return Observable.concat([
    .just(.setLoading(true)),
    Observable.create { observer in
      observer.onNext(())
      observer.onCompleted()
      return Disposables.create()
    }
    .subscribe(on: SerialDispatchQueueScheduler(qos: .userInteractive))
    .observe(on: MainScheduler.instance)
    .flatMap { Observable<Mutation>.empty() },
    Observable.just(.increaseValue),
  ])
```

Reproduces on iOS 17+ only — iOS 13–16 backport channel was unaffected.

Diagnostic trace (pre-fix):

```
[Mutation 1: setLoading(true)]
[_$mutate] willSet \.isLoading
[ObservedReactor] _state ASSIGN, isMain=true       ← sync after reduce
[body] re-eval, isLoading=true, count=0            ← reads fresh state ✓

[BG → Main hop]

[Mutation 2: increaseValue]
[_$mutate] willSet \.isLoading                     ← native willSet (iOS 17+) → SwiftUI re-eval scheduled
[reduce → state.count=1]
[body] re-eval, isLoading=true, count=0            ← !! reads STALE _state
[ObservedReactor] _state ASSIGN, isMain=true       ← !! _state assigned too late
```

## Root Cause

`MainScheduler.instance` shares a process-wide `numberEnqueued` counter. When the user's BG-hop incremented it, `ObservedReactor.init`'s nested `.observe(on: MainScheduler.instance)` fell through from sync passthrough to `dispatch_async`, deferring `_state = newValue` past the body re-eval that the macro's native `Observation.willSet` (fired during `reduce`) just scheduled.

The iOS 13–16 backport channel was always coherent because it fans out willSet from inside the `state` setter — after `_state = newValue` — so timing could not race.

## Fix

`ObservedReactor.init` now subscribes through `_runOnMain(_:)`:

```swift
private nonisolated func _runOnMain(_ block: @escaping @MainActor () -> Void) {
  if Thread.isMainThread {
    MainActor.assumeIsolated(block)
  } else {
    DispatchQueue.main.async {
      MainActor.assumeIsolated(block)
    }
  }
}
```

`Thread.isMainThread` is independent of any process-wide scheduler counter, so on-main emissions always commit `_state` synchronously in the same call stack as the macro's willSet — body re-eval observes fresh state.

## Why not other approaches?

Considered moving native willSet fan-out from `_$mutate` to the `state` setter (mirror the iOS 13–16 backport channel). Rejected because:
- Breaks public ABI for direct `ObservableState` consumers — existing tests assert `var s = State(); s.x = 1` fires native willSet immediately
- Doesn't cover nested `ObservableState` (child registrar fires inside reduce, parent's `_$mutatedKeyPaths` can't reach it)
- `@Pulse` / `_$willModify()` paths bypass `_$mutate` entirely
- Would require redesigning `_$trackMutation` to capture typed willSet thunks (AnyKeyPath fan-out via `unsafeBitCast` is unsound when `Member` is unknown)

## Test plan

- [x] `swift test` — full suite, 147 tests pass (145 prior + 2 new)
- [x] `testBodyReEvaluatesAgainstFreshStateAfterBackgroundHop` fails pre-fix with `count=0 expected 1`, passes post-fix
- [x] `testRepeatedBackgroundHopMutationsPinFreshStateReads` fails pre-fix by trampoline timeout, passes post-fix
- [x] Per-property scoping regression tests in `ObservedReactorObservableStateTests` and `NativeStateObservationProbeTests` all pass
- [ ] Manual verification on iPhone 17 Sim (iOS 26): tap increment in `Examples/SwiftUICounter` repeatedly with the BG-hop pattern; counter advances, spinner clears, alert fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored state update routing to enhance reliability when state changes occur from background operations or asynchronous contexts.

* **Tests**
  * Added comprehensive test coverage validating state observation behavior across concurrent scenarios and background operations, ensuring state snapshots remain accurate and consistent in all execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->